### PR TITLE
Feature/add sites

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	resourceusecase "github.com/davidgaspardev/usermes-backend/internal/modules/resource/application/usecase"
 	resourcehttp "github.com/davidgaspardev/usermes-backend/internal/modules/resource/infrastructure/adapter/input/http"
+	sitehttp "github.com/davidgaspardev/usermes-backend/internal/modules/resource/infrastructure/adapter/input/http/site"
 	resourcepersistence "github.com/davidgaspardev/usermes-backend/internal/modules/resource/infrastructure/adapter/output/persistence"
 	userusecase "github.com/davidgaspardev/usermes-backend/internal/modules/user/application/usecase"
 	userhttp "github.com/davidgaspardev/usermes-backend/internal/modules/user/infrastructure/adapter/input/http"
@@ -38,7 +39,9 @@ func main() {
 
 	// Initialize Resource module
 	resourceRepository := resourcepersistence.NewMemoryResourceRepository()
+	siteRepository := resourcepersistence.NewMemorySiteRepository()
 	resourceService := resourceusecase.NewResourceService(resourceRepository)
+	siteService := resourceusecase.NewSiteService(siteRepository)
 
 	// Initialize HTTP server
 	serverConfig := server.DefaultConfig()
@@ -58,6 +61,9 @@ func main() {
 	// Resource module routes
 	resourceRoutes := resourcehttp.NewResourceRoutes(resourceService)
 	httpServer.RegisterRoutes(resourceRoutes.SetupRoutes)
+
+	siteRoutes := sitehttp.NewSiteRoutes(siteService)
+	httpServer.RegisterRoutes(siteRoutes.SetupRoutes)
 
 	// Start server
 	log.Printf("Starting %s on port %d", config.AppName, config.ServerPort)

--- a/internal/modules/resource/application/port/input/site_service.go
+++ b/internal/modules/resource/application/port/input/site_service.go
@@ -1,0 +1,18 @@
+package input
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/domain/entity"
+)
+
+type SiteService interface {
+	Create(
+		ctx context.Context,
+		code, name string,
+		latitude, longitude float64,
+		ownerID uuid.UUID,
+	) (*entity.Site, error)
+}

--- a/internal/modules/resource/application/port/output/site_repository.go
+++ b/internal/modules/resource/application/port/output/site_repository.go
@@ -1,0 +1,11 @@
+package output
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/domain/entity"
+)
+
+type SiteRepository interface {
+	Create(ctx context.Context, site *entity.Site) error
+}

--- a/internal/modules/resource/application/usecase/site_service_impl.go
+++ b/internal/modules/resource/application/usecase/site_service_impl.go
@@ -1,0 +1,35 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/application/port/output"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/domain/entity"
+	"github.com/google/uuid"
+)
+
+type SiteService struct {
+	siteRepo output.SiteRepository
+}
+
+func NewSiteService(
+	siteRepo output.SiteRepository,
+) input.SiteService {
+	return &SiteService{}
+}
+
+func (s *SiteService) Create(
+	ctx context.Context,
+	code, name string,
+	latitude, longitude float64,
+	ownerID uuid.UUID,
+) (*entity.Site, error) {
+	var createAt, updateAt = time.Now(), time.Now()
+	site := entity.NewSite(code, name, latitude, longitude, ownerID, createAt, updateAt)
+	if err := s.siteRepo.Create(ctx, site); err != nil {
+		return nil, err
+	}
+	return site, nil
+}

--- a/internal/modules/resource/domain/entity/site.go
+++ b/internal/modules/resource/domain/entity/site.go
@@ -1,0 +1,29 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Site struct {
+	createAt  time.Time
+	updateAt  time.Time
+	Code      string
+	Name      string
+	Latitude  float64
+	Longitude float64
+	OwnerID   uuid.UUID
+}
+
+func NewSite(code, name string, latitude, longitude float64, ownerID uuid.UUID, createAt, updateAt time.Time) *Site {
+	return &Site{
+		createAt:  createAt,
+		updateAt:  updateAt,
+		Code:      code,
+		Name:      name,
+		Latitude:  latitude,
+		Longitude: longitude,
+		OwnerID:   ownerID,
+	}
+}

--- a/internal/modules/resource/infrastructure/adapter/input/http/site/routes.go
+++ b/internal/modules/resource/infrastructure/adapter/input/http/site/routes.go
@@ -1,0 +1,22 @@
+package site
+
+import (
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/application/port/input"
+	"github.com/gofiber/fiber/v2"
+)
+
+type SiteRoutes struct {
+	handler *SiteHandler
+}
+
+func NewSiteRoutes(siteService input.SiteService) *SiteRoutes {
+	return &SiteRoutes{
+		handler: NewSiteHandler(siteService),
+	}
+}
+
+func (r *SiteRoutes) SetupRoutes(app *fiber.App) {
+	sites := app.Group("/api/sites")
+
+	sites.Post("/", r.handler.Create)
+}

--- a/internal/modules/resource/infrastructure/adapter/input/http/site/site_handler.go
+++ b/internal/modules/resource/infrastructure/adapter/input/http/site/site_handler.go
@@ -1,0 +1,48 @@
+package site
+
+import (
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/infrastructure/dto"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+type SiteHandler struct {
+	service input.SiteService
+}
+
+func NewSiteHandler(service input.SiteService) *SiteHandler {
+	return &SiteHandler{
+		service: service,
+	}
+}
+
+func (h *SiteHandler) Create(c *fiber.Ctx) error {
+	var req dto.CreateSiteRequest
+
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
+			"invalid_request",
+			"Invalid request body",
+		))
+	}
+
+	userID, err := uuid.NewUUID()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(dto.NewErrorResponse(
+			"internal_error",
+			"Failed to generate UUID",
+		))
+	}
+
+	site, err := h.service.Create(c.Context(), req.Code, req.Name, req.Latitude, req.Longitude, userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(dto.NewErrorResponse(
+			"internal_error",
+			"Failed to create site",
+		))
+	}
+
+	response := dto.ToSiteResponse(site)
+	return c.Status(fiber.StatusCreated).JSON(response)
+}

--- a/internal/modules/resource/infrastructure/adapter/output/persistence/memory_site_repository.go
+++ b/internal/modules/resource/infrastructure/adapter/output/persistence/memory_site_repository.go
@@ -1,0 +1,28 @@
+package persistence
+
+import (
+	"context"
+	"sync"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/application/port/output"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/resource/domain/entity"
+)
+
+type MemorySiteRepository struct {
+	sites map[string]*entity.Site
+	mu    sync.RWMutex
+}
+
+func NewMemorySiteRepository() output.SiteRepository {
+	return &MemorySiteRepository{
+		sites: make(map[string]*entity.Site),
+	}
+}
+
+func (r *MemorySiteRepository) Create(ctx context.Context, site *entity.Site) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.sites[site.Code] = site
+	return nil
+}

--- a/internal/modules/resource/infrastructure/dto/site_dto.go
+++ b/internal/modules/resource/infrastructure/dto/site_dto.go
@@ -1,0 +1,28 @@
+package dto
+
+import "github.com/davidgaspardev/usermes-backend/internal/modules/resource/domain/entity"
+
+type CreateSiteRequest struct {
+	Code      string  `json:"code" validate:"required"`
+	Name      string  `json:"name" validate:"required"`
+	Latitude  float64 `json:"latitude" validate:"required"`
+	Longitude float64 `json:"longitude" validate:"required"`
+}
+
+type SiteResponse struct {
+	Code      string  `json:"code"`
+	Name      string  `json:"name"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+	OwnerID   string  `json:"owner_id"`
+}
+
+func ToSiteResponse(site *entity.Site) *SiteResponse {
+	return &SiteResponse{
+		Code:      site.Code,
+		Name:      site.Name,
+		Latitude:  site.Latitude,
+		Longitude: site.Longitude,
+		OwnerID:   site.OwnerID.String(),
+	}
+}


### PR DESCRIPTION
This pull request introduces a new structure for managing "Site" entities in the resource module, implementing both the domain model and the application layer for site creation. The main changes include the definition of the `Site` entity, creation of input/output ports for service and repository abstraction, and the implementation of the site creation use case.

**Domain Model:**

* Added the `Site` entity in `site.go`, encapsulating properties like code, name, latitude, longitude, owner ID, and timestamps, along with a constructor function `NewSite`.

**Application Layer:**

* Defined the `SiteService` input port interface in `site_service.go` for creating sites, specifying required parameters and return types.
* Defined the `SiteRepository` output port interface in `site_repository.go` to abstract site persistence operations.

**Use Case Implementation:**

* Implemented the `SiteService` use case in `site_service_impl.go`, including the constructor and the `Create` method, which instantiates a `Site` entity and delegates persistence to the repository.