### PR TITLE
✨ Feature | Add location tree CRUD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: "v2"
           args: --timeout=5m
           skip-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: go mod download
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: "v2.0.2"
           args: --timeout=5m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: "v2"
+          version: "v2.0.2"
           args: --timeout=5m
           skip-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,45 @@
-# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
-# golangci-lint minimal configuration
-# Focused on essential linters following Go community best practices
+# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.v2.jsonschema.json
+
+version: "2"
 
 run:
   timeout: 5m
   tests: true
   modules-download-mode: readonly
 
-linters:
-  disable-all: true
+formatters:
   enable:
-    # Code formatting and style
-    - gofmt # Standard Go formatter
-    - goimports # Organizes imports
+    - gofmt
+    - goimports
 
-    # Official Go tooling
-    - govet # Official Go static analyzer
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/davidgaspardev/usermes-backend
 
-    # High-quality, widely-adopted linters
-    - staticcheck # Most trusted linter in Go community
-    - errcheck # Checks for unchecked errors
-    - gosimple # Simplifies code
-    - ineffassign # Detects ineffectual assignments
-    - unused # Finds unused code
+linters:
+  enable:
+    # Official tooling
+    - govet
 
-    # Security and best practices
-    - gosec # Security issues
-    - revive # Modern replacement for golint
+    # High-quality linters
+    - staticcheck
+    - errcheck
+    - ineffassign
+    - unused
+
+    # Security & best practices
+    - gosec
+    - revive
 
     # Common mistakes
-    - typecheck # Type checking
-    - bodyclose # HTTP response body must be closed
+    - bodyclose
 
 linters-settings:
   govet:
     enable-all: true
     disable:
-      - shadow # Too noisy for most projects
-
-  goimports:
-    local-prefixes: github.com/davidgaspardev/usermes-backend
+      - shadow
 
   revive:
     rules:
@@ -47,7 +47,9 @@ linters-settings:
         disabled: false
 
 issues:
-  # Exclude some checks in test files
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
   exclude-rules:
     - path: _test\.go
       linters:
@@ -58,13 +60,10 @@ issues:
       linters:
         - revive
 
-  # Show all issues
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
 output:
   formats:
-    - format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-  sort-results: true
+    text:
+      path: stdout
+      print-issued-lines: true
+      print-linter-name: true
+      colors: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,30 +35,31 @@ linters:
     # Common mistakes
     - bodyclose
 
-linters-settings:
-  govet:
-    enable-all: true
-    disable:
-      - shadow
+  settings:
+    govet:
+      enable-all: true
+      disable:
+        - shadow
 
-  revive:
-    rules:
-      - name: exported
-        disabled: false
+    revive:
+      rules:
+        - name: exported
+          disabled: false
 
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-        - gosec
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gosec
 
-    - path: cmd/
-      linters:
-        - revive
+      - path: cmd/
+        linters:
+          - revive
 
 output:
   formats:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,10 +46,6 @@ linters:
         - name: exported
           disabled: false
 
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
   exclusions:
     rules:
       - path: _test\.go
@@ -60,6 +56,10 @@ issues:
       - path: cmd/
         linters:
           - revive
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
 output:
   formats:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,8 +108,7 @@ func loadConfig() Config {
 		if p, valid := parseValidPort(portStr); valid {
 			port = p
 		} else {
-			log.Printf("Warning: Invalid PORT value '%s' (must be 1-65535), using default port %d", portStr, DefaultServerPort)
-		}
+			log.Printf("Warning: Invalid PORT value %q (must be 1-65535), using default port %d", portStr, DefaultServerPort)
 	}
 
 	return Config{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,7 +81,7 @@ func main() {
 // Config holds the application configuration
 type Config struct {
 	AppName       string
-	JWTSecret     string
+	JWTSecret     string //nolint:gosec // intentional: config struct holds the secret by design
 	TokenDuration time.Duration
 	ServerPort    int
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,7 +108,8 @@ func loadConfig() Config {
 		if p, valid := parseValidPort(portStr); valid {
 			port = p
 		} else {
-			log.Printf("Warning: Invalid PORT value %q (must be 1-65535), using default port %d", portStr, DefaultServerPort)
+			log.Printf("Warning: Invalid PORT value %q (must be 1-65535), using default port %d", portStr, DefaultServerPort) //nolint:gosec // %q escapes all control characters, preventing log injection
+		}
 	}
 
 	return Config{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,8 @@ import (
 	iamusecase "github.com/davidgaspardev/usermes-backend/internal/modules/iam/application/usecase"
 	iamhttp "github.com/davidgaspardev/usermes-backend/internal/modules/iam/infrastructure/adapter/input/http"
 	iampersistence "github.com/davidgaspardev/usermes-backend/internal/modules/iam/infrastructure/adapter/output/persistence"
+	organizationhttp "github.com/davidgaspardev/usermes-backend/internal/modules/organization/infrastructure/adapter/input/http"
+	organizationpersistence "github.com/davidgaspardev/usermes-backend/internal/modules/organization/infrastructure/adapter/output/persistence"
 	productionusecase "github.com/davidgaspardev/usermes-backend/internal/modules/production/application/usecase"
 	productionhttp "github.com/davidgaspardev/usermes-backend/internal/modules/production/infrastructure/adapter/input/http"
 	productionpersistence "github.com/davidgaspardev/usermes-backend/internal/modules/production/infrastructure/adapter/output/persistence"
@@ -36,6 +38,9 @@ func main() {
 		config.TokenDuration,
 	)
 
+	// Initialize Organization module
+	locationRepository := organizationpersistence.NewLocationRepositoryInMemory()
+
 	// Initialize Resource module
 	resourceRepository := productionpersistence.NewMemoryResourceRepository()
 	resourceService := productionusecase.NewResourceService(resourceRepository)
@@ -54,6 +59,10 @@ func main() {
 	// IAM module routes
 	iamRoutes := iamhttp.NewIAMRoutes(userService, tokenGenerator)
 	httpServer.RegisterRoutes(iamRoutes.SetupRoutes)
+
+	// Organization module routes
+	organizationRoutes := organizationhttp.NewOrganizationRoutes(locationRepository)
+	httpServer.RegisterRoutes(organizationRoutes.SetupRoutes)
 
 	// Production module routes
 	productionRoutes := productionhttp.NewProductionRoutes(resourceService)

--- a/internal/modules/iam/infrastructure/dto/user_dto.go
+++ b/internal/modules/iam/infrastructure/dto/user_dto.go
@@ -11,7 +11,7 @@ import (
 // RegisterRequest represents the request body for user registration
 type RegisterRequest struct {
 	Email    string `json:"email"`
-	Password string `json:"password"`
+	Password string `json:"password"` //nolint:gosec // intentional: request DTO receives user-provided password
 	Username string `json:"username"`
 	Name     string `json:"name"`
 }
@@ -19,7 +19,7 @@ type RegisterRequest struct {
 // LoginRequest represents the request body for user login
 type LoginRequest struct {
 	Username string `json:"username"`
-	Password string `json:"password"`
+	Password string `json:"password"` //nolint:gosec // intentional: request DTO receives user-provided password
 }
 
 // UpdateUserRequest represents the request body for updating user information

--- a/internal/modules/iam/infrastructure/dto/user_dto.go
+++ b/internal/modules/iam/infrastructure/dto/user_dto.go
@@ -101,7 +101,7 @@ func NewSuccessResponse(message string, data interface{}) SuccessResponse {
 	}
 }
 
-// ValidateRegisterRequest validates the register request
+// Validate validates the register request.
 func (r *RegisterRequest) Validate() error {
 	if r.Email == "" {
 		return &ValidationError{Field: "email", Message: "email is required"}
@@ -118,7 +118,7 @@ func (r *RegisterRequest) Validate() error {
 	return nil
 }
 
-// ValidateLoginRequest validates the login request
+// Validate validates the login request.
 func (r *LoginRequest) Validate() error {
 	if r.Username == "" {
 		return &ValidationError{Field: "username", Message: "username is required"}
@@ -129,7 +129,7 @@ func (r *LoginRequest) Validate() error {
 	return nil
 }
 
-// ValidateUpdateUserRequest validates the update user request
+// Validate validates the update user request.
 func (r *UpdateUserRequest) Validate() error {
 	if r.Name == "" {
 		return &ValidationError{Field: "name", Message: "name is required"}
@@ -137,7 +137,7 @@ func (r *UpdateUserRequest) Validate() error {
 	return nil
 }
 
-// ValidateChangePasswordRequest validates the change password request
+// Validate validates the change password request.
 func (r *ChangePasswordRequest) Validate() error {
 	if r.OldPassword == "" {
 		return &ValidationError{Field: "old_password", Message: "old password is required"}

--- a/internal/modules/organization/application/port/input/add_location_use_case.go
+++ b/internal/modules/organization/application/port/input/add_location_use_case.go
@@ -14,5 +14,5 @@ type AddLocationCommand struct {
 }
 
 type AddLocationUseCase interface {
-	Execute(ctx *context.Context, command AddLocationCommand) (*entity.Location, error)
+	Execute(ctx context.Context, command AddLocationCommand) (*entity.Location, error)
 }

--- a/internal/modules/organization/application/port/input/add_location_use_case.go
+++ b/internal/modules/organization/application/port/input/add_location_use_case.go
@@ -1,0 +1,18 @@
+package input
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+)
+
+type AddLocationCommand struct {
+	Code       string
+	Name       string
+	ParentCode string
+	RootCode   string
+}
+
+type AddLocationUseCase interface {
+	Execute(ctx *context.Context, command AddLocationCommand) (*entity.Location, error)
+}

--- a/internal/modules/organization/application/port/input/add_location_use_case.go
+++ b/internal/modules/organization/application/port/input/add_location_use_case.go
@@ -6,6 +6,7 @@ import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
+// AddLocationCommand holds the input data for adding a location to an existing tree.
 type AddLocationCommand struct {
 	Code       string
 	Name       string
@@ -14,6 +15,7 @@ type AddLocationCommand struct {
 	RootCode   string
 }
 
+// AddLocationUseCase defines the use case for adding a child location.
 type AddLocationUseCase interface {
 	Execute(ctx context.Context, command AddLocationCommand) (*entity.Location, error)
 }

--- a/internal/modules/organization/application/port/input/add_location_use_case.go
+++ b/internal/modules/organization/application/port/input/add_location_use_case.go
@@ -9,6 +9,7 @@ import (
 type AddLocationCommand struct {
 	Code       string
 	Name       string
+	Kind       string
 	ParentCode string
 	RootCode   string
 }

--- a/internal/modules/organization/application/port/input/create_location_root_use_case.go
+++ b/internal/modules/organization/application/port/input/create_location_root_use_case.go
@@ -1,0 +1,16 @@
+package input
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+)
+
+type CreateLocationRootCommand struct {
+	Code string
+	Name string
+}
+
+type CreateLocationRootUseCase interface {
+	Execute(ctx context.Context, command CreateLocationRootCommand) (*entity.Location, error)
+}

--- a/internal/modules/organization/application/port/input/create_location_root_use_case.go
+++ b/internal/modules/organization/application/port/input/create_location_root_use_case.go
@@ -6,11 +6,13 @@ import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
+// CreateLocationRootCommand holds the input data for creating a root location.
 type CreateLocationRootCommand struct {
 	Code string
 	Name string
 }
 
+// CreateLocationRootUseCase defines the use case for creating a root location.
 type CreateLocationRootUseCase interface {
 	Execute(ctx context.Context, command CreateLocationRootCommand) (*entity.Location, error)
 }

--- a/internal/modules/organization/application/port/input/get_all_locations_usecase.go
+++ b/internal/modules/organization/application/port/input/get_all_locations_usecase.go
@@ -1,0 +1,11 @@
+package input
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+)
+
+type GetAllLocationsUseCase interface {
+	Execute(ctx context.Context) ([]entity.Location, error)
+}

--- a/internal/modules/organization/application/port/input/get_all_locations_usecase.go
+++ b/internal/modules/organization/application/port/input/get_all_locations_usecase.go
@@ -6,6 +6,7 @@ import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
+// GetAllLocationsUseCase defines the use case for retrieving all locations.
 type GetAllLocationsUseCase interface {
 	Execute(ctx context.Context) ([]entity.Location, error)
 }

--- a/internal/modules/organization/application/port/output/location_repository.go
+++ b/internal/modules/organization/application/port/output/location_repository.go
@@ -5,5 +5,5 @@ import "github.com/davidgaspardev/usermes-backend/internal/modules/organization/
 type LocationRepository interface {
 	Create(location *entity.Location) error
 	FindTree(rootCode string) (*entity.Location, error)
-	FindByCode(code string) (*entity.Location, error)
+	ExistsByCode(code string) (bool, error)
 }

--- a/internal/modules/organization/application/port/output/location_repository.go
+++ b/internal/modules/organization/application/port/output/location_repository.go
@@ -2,6 +2,7 @@ package output
 
 import "github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 
+// LocationRepository defines the persistence port for location data.
 type LocationRepository interface {
 	Create(location *entity.Location) error
 	FindTree(rootCode string) (*entity.Location, error)

--- a/internal/modules/organization/application/port/output/location_repository.go
+++ b/internal/modules/organization/application/port/output/location_repository.go
@@ -6,4 +6,5 @@ type LocationRepository interface {
 	Create(location *entity.Location) error
 	FindTree(rootCode string) (*entity.Location, error)
 	ExistsByCode(code string) (bool, error)
+	GetAll() ([]entity.Location, error)
 }

--- a/internal/modules/organization/application/port/output/location_repository.go
+++ b/internal/modules/organization/application/port/output/location_repository.go
@@ -1,0 +1,9 @@
+package output
+
+import "github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+
+type LocationRepository interface {
+	Create(location *entity.Location) error
+	FindTree(rootCode string) (*entity.Location, error)
+	FindByCode(code string) (*entity.Location, error)
+}

--- a/internal/modules/organization/application/usecase/add_location_use_case.go
+++ b/internal/modules/organization/application/usecase/add_location_use_case.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
+)
+
+type addLocationUseCaseImpl struct {
+	locationRepository output.LocationRepository
+}
+
+func NewAddLocationUseCaseImpl(locationRepository output.LocationRepository) input.AddLocationUseCase {
+	return &addLocationUseCaseImpl{
+		locationRepository: locationRepository,
+	}
+}
+
+func (uc *addLocationUseCaseImpl) Execute(ctx *context.Context, command input.AddLocationCommand) (*entity.Location, error) {
+	if !validateCommand(&command) {
+		return nil, errors.ErrInvalidLocationCommand
+	}
+
+	locationTree, err := uc.locationRepository.FindTree(command.RootCode)
+	if err != nil {
+		return nil, err
+	}
+
+	if locationTree == nil {
+		return nil, errors.ErrLocationTreeNotFound
+	}
+
+	parentLocation, err := locationTree.FindByCode(command.ParentCode)
+	if err != nil {
+		return nil, err
+	}
+
+	if parentLocation == nil {
+		return nil, errors.ErrLocationNotFound
+	}
+
+	location := entity.NewLocation(
+		command.Code,
+		command.Name,
+		parentLocation,
+	)
+	parentLocation.AddChild(location)
+
+	if err := uc.locationRepository.Create(location); err != nil {
+		return nil, err
+	}
+
+	return locationTree, nil
+}
+
+func validateCommand(command *input.AddLocationCommand) bool {
+	return command.Code != "" &&
+		command.Name != "" &&
+		command.ParentCode != "" &&
+		command.RootCode != "" &&
+		command.Code != command.RootCode &&
+		command.Code != command.ParentCode
+}

--- a/internal/modules/organization/application/usecase/add_location_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/add_location_use_case_impl.go
@@ -45,6 +45,7 @@ func (uc *addLocationUseCaseImpl) Execute(ctx context.Context, command input.Add
 	location := entity.NewLocation(
 		command.Code,
 		command.Name,
+		entity.LocationKind(command.Kind),
 		parentLocation,
 	)
 	parentLocation.AddChild(location)
@@ -62,5 +63,7 @@ func isCommandValid(command *input.AddLocationCommand) bool {
 		command.ParentCode != "" &&
 		command.RootCode != "" &&
 		command.Code != command.RootCode &&
-		command.Code != command.ParentCode
+		command.Code != command.ParentCode &&
+		entity.IsValidLocationKind(command.Kind) &&
+		command.Kind != string(entity.LocationKindPlant)
 }

--- a/internal/modules/organization/application/usecase/add_location_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/add_location_use_case_impl.go
@@ -13,6 +13,7 @@ type addLocationUseCaseImpl struct {
 	locationRepository output.LocationRepository
 }
 
+// NewAddLocationUseCase creates a new AddLocationUseCase instance.
 func NewAddLocationUseCase(locationRepository output.LocationRepository) input.AddLocationUseCase {
 	return &addLocationUseCaseImpl{
 		locationRepository: locationRepository,

--- a/internal/modules/organization/application/usecase/add_location_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/add_location_use_case_impl.go
@@ -48,11 +48,12 @@ func (uc *addLocationUseCaseImpl) Execute(ctx context.Context, command input.Add
 		entity.LocationKind(command.Kind),
 		parentLocation,
 	)
-	parentLocation.AddChild(location)
 
 	if err := uc.locationRepository.Create(location); err != nil {
 		return nil, err
 	}
+
+	parentLocation.AddChild(location)
 
 	return locationTree, nil
 }

--- a/internal/modules/organization/application/usecase/add_location_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/add_location_use_case_impl.go
@@ -13,13 +13,13 @@ type addLocationUseCaseImpl struct {
 	locationRepository output.LocationRepository
 }
 
-func NewAddLocationUseCaseImpl(locationRepository output.LocationRepository) input.AddLocationUseCase {
+func NewAddLocationUseCase(locationRepository output.LocationRepository) input.AddLocationUseCase {
 	return &addLocationUseCaseImpl{
 		locationRepository: locationRepository,
 	}
 }
 
-func (uc *addLocationUseCaseImpl) Execute(ctx *context.Context, command input.AddLocationCommand) (*entity.Location, error) {
+func (uc *addLocationUseCaseImpl) Execute(ctx context.Context, command input.AddLocationCommand) (*entity.Location, error) {
 	if !validateCommand(&command) {
 		return nil, errors.ErrInvalidLocationCommand
 	}

--- a/internal/modules/organization/application/usecase/add_location_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/add_location_use_case_impl.go
@@ -20,7 +20,7 @@ func NewAddLocationUseCase(locationRepository output.LocationRepository) input.A
 }
 
 func (uc *addLocationUseCaseImpl) Execute(ctx context.Context, command input.AddLocationCommand) (*entity.Location, error) {
-	if !validateCommand(&command) {
+	if !isCommandValid(&command) {
 		return nil, errors.ErrInvalidLocationCommand
 	}
 
@@ -33,11 +33,11 @@ func (uc *addLocationUseCaseImpl) Execute(ctx context.Context, command input.Add
 		return nil, errors.ErrLocationTreeNotFound
 	}
 
-	parentLocation, err := locationTree.FindByCode(command.ParentCode)
-	if err != nil {
-		return nil, err
+	if locationAlreadyExists := locationTree.ExistsByLocation(command.Code); locationAlreadyExists {
+		return nil, errors.ErrLocationAlreadyExists
 	}
 
+	parentLocation := locationTree.FindByCode(command.ParentCode)
 	if parentLocation == nil {
 		return nil, errors.ErrLocationNotFound
 	}
@@ -56,7 +56,7 @@ func (uc *addLocationUseCaseImpl) Execute(ctx context.Context, command input.Add
 	return locationTree, nil
 }
 
-func validateCommand(command *input.AddLocationCommand) bool {
+func isCommandValid(command *input.AddLocationCommand) bool {
 	return command.Code != "" &&
 		command.Name != "" &&
 		command.ParentCode != "" &&

--- a/internal/modules/organization/application/usecase/add_location_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/add_location_use_case_impl.go
@@ -33,7 +33,7 @@ func (uc *addLocationUseCaseImpl) Execute(ctx context.Context, command input.Add
 		return nil, errors.ErrLocationTreeNotFound
 	}
 
-	if locationAlreadyExists := locationTree.ExistsByLocation(command.Code); locationAlreadyExists {
+	if locationAlreadyExists := locationTree.ExistsByCode(command.Code); locationAlreadyExists {
 		return nil, errors.ErrLocationAlreadyExists
 	}
 

--- a/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
@@ -22,12 +22,12 @@ func NewCreateLocationRootUseCase(
 }
 
 func (uc *createLocationRootUseCaseImpl) Execute(ctx context.Context, command input.CreateLocationRootCommand) (*entity.Location, error) {
-	locationExists, err := uc.locationRepository.FindByCode(command.Code)
+	locationExists, err := uc.locationRepository.ExistsByCode(command.Code)
 	if err != nil {
 		return nil, err
 	}
 
-	if locationExists != nil {
+	if locationExists {
 		return nil, errors.ErrLocationAlreadyExists
 	}
 

--- a/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
@@ -1,0 +1,43 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
+)
+
+type createLocationRootUseCaseImpl struct {
+	locationRepository output.LocationRepository
+}
+
+func NewCreateLocationRootUseCase(
+	locationRepository output.LocationRepository,
+) input.CreateLocationRootUseCase {
+	return &createLocationRootUseCaseImpl{
+		locationRepository: locationRepository,
+	}
+}
+
+func (uc *createLocationRootUseCaseImpl) Execute(ctx context.Context, command input.CreateLocationRootCommand) (*entity.Location, error) {
+	locationExists, err := uc.locationRepository.FindByCode(command.Code)
+	if err != nil {
+		return nil, err
+	}
+
+	if locationExists != nil {
+		return nil, errors.ErrLocationAlreadyExists
+	}
+
+	location := entity.NewRootLocation(
+		command.Code,
+		command.Name,
+	)
+	if err := uc.locationRepository.Create(location); err != nil {
+		return nil, err
+	}
+
+	return location, nil
+}

--- a/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
@@ -13,6 +13,7 @@ type createLocationRootUseCaseImpl struct {
 	locationRepository output.LocationRepository
 }
 
+// NewCreateLocationRootUseCase creates a new CreateLocationRootUseCase instance.
 func NewCreateLocationRootUseCase(
 	locationRepository output.LocationRepository,
 ) input.CreateLocationRootUseCase {

--- a/internal/modules/organization/application/usecase/get_all_locations_usecase.go
+++ b/internal/modules/organization/application/usecase/get_all_locations_usecase.go
@@ -1,0 +1,23 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+)
+
+type getAllLocationsUseCase struct {
+	locationRepo output.LocationRepository
+}
+
+func NewGetAllLocationsUseCase(locationRepo output.LocationRepository) input.GetAllLocationsUseCase {
+	return &getAllLocationsUseCase{
+		locationRepo: locationRepo,
+	}
+}
+
+func (uc *getAllLocationsUseCase) Execute(ctx context.Context) ([]entity.Location, error) {
+	return uc.locationRepo.GetAll()
+}

--- a/internal/modules/organization/application/usecase/get_all_locations_usecase.go
+++ b/internal/modules/organization/application/usecase/get_all_locations_usecase.go
@@ -12,6 +12,7 @@ type getAllLocationsUseCase struct {
 	locationRepo output.LocationRepository
 }
 
+// NewGetAllLocationsUseCase creates a new GetAllLocationsUseCase instance.
 func NewGetAllLocationsUseCase(locationRepo output.LocationRepository) input.GetAllLocationsUseCase {
 	return &getAllLocationsUseCase{
 		locationRepo: locationRepo,

--- a/internal/modules/organization/application/usecase/location_use_cases_test.go
+++ b/internal/modules/organization/application/usecase/location_use_cases_test.go
@@ -1,0 +1,216 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/infrastructure/adapter/output/persistence"
+)
+
+func TestCreateLocationRootUseCase_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates root location successfully", func(t *testing.T) {
+		repo := persistence.NewLocationRepositoryInMemory()
+		uc := NewCreateLocationRootUseCase(repo)
+
+		loc, err := uc.Execute(ctx, input.CreateLocationRootCommand{
+			Code: "PLANT01",
+			Name: "Plant One",
+		})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if loc == nil {
+			t.Fatal("Expected location, got nil")
+		}
+		if loc.Code() != "PLANT01" {
+			t.Errorf("Expected code PLANT01, got %s", loc.Code())
+		}
+	})
+
+	t.Run("returns error when location already exists", func(t *testing.T) {
+		repo := persistence.NewLocationRepositoryInMemory()
+		uc := NewCreateLocationRootUseCase(repo)
+		cmd := input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"}
+
+		_, err := uc.Execute(ctx, cmd)
+		if err != nil {
+			t.Fatalf("First creation should succeed, got %v", err)
+		}
+
+		_, err = uc.Execute(ctx, cmd)
+		if err != errors.ErrLocationAlreadyExists {
+			t.Errorf("Expected ErrLocationAlreadyExists, got %v", err)
+		}
+	})
+}
+
+func TestAddLocationUseCase_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	setup := func() (input.AddLocationUseCase, input.CreateLocationRootUseCase) {
+		repo := persistence.NewLocationRepositoryInMemory()
+		return NewAddLocationUseCase(repo), NewCreateLocationRootUseCase(repo)
+	}
+
+	t.Run("adds child location successfully", func(t *testing.T) {
+		addUC, createUC := setup()
+
+		_, err := createUC.Execute(ctx, input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"})
+		if err != nil {
+			t.Fatalf("Setup failed: %v", err)
+		}
+
+		tree, err := addUC.Execute(ctx, input.AddLocationCommand{
+			Code:       "AREA01",
+			Name:       "Area One",
+			Kind:       "AREA",
+			ParentCode: "PLANT01",
+			RootCode:   "PLANT01",
+		})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if tree == nil {
+			t.Fatal("Expected tree, got nil")
+		}
+		if !tree.ExistsByCode("AREA01") {
+			t.Error("Expected AREA01 to exist in tree")
+		}
+	})
+
+	t.Run("returns error when root tree not found", func(t *testing.T) {
+		addUC, _ := setup()
+
+		_, err := addUC.Execute(ctx, input.AddLocationCommand{
+			Code:       "AREA01",
+			Name:       "Area One",
+			Kind:       "AREA",
+			ParentCode: "PLANT01",
+			RootCode:   "PLANT01",
+		})
+
+		if err != errors.ErrLocationTreeNotFound {
+			t.Errorf("Expected ErrLocationTreeNotFound, got %v", err)
+		}
+	})
+
+	t.Run("returns error when location already exists", func(t *testing.T) {
+		addUC, createUC := setup()
+
+		_, err := createUC.Execute(ctx, input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"})
+		if err != nil {
+			t.Fatalf("Setup failed: %v", err)
+		}
+
+		cmd := input.AddLocationCommand{
+			Code: "AREA01", Name: "Area One", Kind: "AREA",
+			ParentCode: "PLANT01", RootCode: "PLANT01",
+		}
+		_, err = addUC.Execute(ctx, cmd)
+		if err != nil {
+			t.Fatalf("First add should succeed, got %v", err)
+		}
+
+		_, err = addUC.Execute(ctx, cmd)
+		if err != errors.ErrLocationAlreadyExists {
+			t.Errorf("Expected ErrLocationAlreadyExists, got %v", err)
+		}
+	})
+
+	t.Run("returns error when parent not found", func(t *testing.T) {
+		addUC, createUC := setup()
+
+		_, err := createUC.Execute(ctx, input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"})
+		if err != nil {
+			t.Fatalf("Setup failed: %v", err)
+		}
+
+		_, err = addUC.Execute(ctx, input.AddLocationCommand{
+			Code:       "AREA01",
+			Name:       "Area One",
+			Kind:       "AREA",
+			ParentCode: "NONEXISTENT",
+			RootCode:   "PLANT01",
+		})
+
+		if err != errors.ErrLocationNotFound {
+			t.Errorf("Expected ErrLocationNotFound, got %v", err)
+		}
+	})
+
+	t.Run("returns error for invalid command", func(t *testing.T) {
+		addUC, _ := setup()
+
+		_, err := addUC.Execute(ctx, input.AddLocationCommand{})
+		if err != errors.ErrInvalidLocationCommand {
+			t.Errorf("Expected ErrInvalidLocationCommand, got %v", err)
+		}
+	})
+
+	t.Run("returns error when kind is PLANT", func(t *testing.T) {
+		addUC, createUC := setup()
+
+		_, err := createUC.Execute(ctx, input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"})
+		if err != nil {
+			t.Fatalf("Setup failed: %v", err)
+		}
+
+		_, err = addUC.Execute(ctx, input.AddLocationCommand{
+			Code:       "PLANT02",
+			Name:       "Plant Two",
+			Kind:       "PLANT",
+			ParentCode: "PLANT01",
+			RootCode:   "PLANT01",
+		})
+
+		if err != errors.ErrInvalidLocationCommand {
+			t.Errorf("Expected ErrInvalidLocationCommand, got %v", err)
+		}
+	})
+}
+
+func TestGetAllLocationsUseCase_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns empty list when no locations", func(t *testing.T) {
+		repo := persistence.NewLocationRepositoryInMemory()
+		uc := NewGetAllLocationsUseCase(repo)
+
+		locations, err := uc.Execute(ctx)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(locations) != 0 {
+			t.Errorf("Expected empty list, got %d", len(locations))
+		}
+	})
+
+	t.Run("returns all root locations", func(t *testing.T) {
+		repo := persistence.NewLocationRepositoryInMemory()
+		createUC := NewCreateLocationRootUseCase(repo)
+		getAllUC := NewGetAllLocationsUseCase(repo)
+
+		_, err := createUC.Execute(ctx, input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"})
+		if err != nil {
+			t.Fatalf("Setup failed: %v", err)
+		}
+		_, err = createUC.Execute(ctx, input.CreateLocationRootCommand{Code: "PLANT02", Name: "Plant Two"})
+		if err != nil {
+			t.Fatalf("Setup failed: %v", err)
+		}
+
+		locations, err := getAllUC.Execute(ctx)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(locations) != 2 {
+			t.Errorf("Expected 2 locations, got %d", len(locations))
+		}
+	})
+}

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -4,8 +4,10 @@ import (
 	"time"
 )
 
+// LocationKind represents the type of a location in the organization hierarchy.
 type LocationKind string
 
+// Valid LocationKind values for the organization hierarchy.
 const (
 	LocationKindPlant   LocationKind = "PLANT"
 	LocationKindArea    LocationKind = "AREA"
@@ -13,16 +15,18 @@ const (
 	LocationKindSection LocationKind = "SECTION"
 )
 
+// Location represents a node in the organization location tree.
 type Location struct {
 	createdAt time.Time
 	updatedAt time.Time
 	parent    *Location
-	children  []*Location
 	code      string
 	name      string
 	kind      LocationKind
+	children  []*Location
 }
 
+// NewLocation creates a new Location with the given attributes.
 func NewLocation(code string, name string, kind LocationKind, parent *Location) *Location {
 	now := time.Now()
 	return &Location{
@@ -36,22 +40,27 @@ func NewLocation(code string, name string, kind LocationKind, parent *Location) 
 	}
 }
 
+// NewRootLocation creates a new root Location (plant level) with no parent.
 func NewRootLocation(code string, name string) *Location {
 	return NewLocation(code, name, LocationKindPlant, nil)
 }
 
+// Code returns the location's unique code.
 func (l *Location) Code() string {
 	return l.code
 }
 
+// Name returns the location's display name.
 func (l *Location) Name() string {
 	return l.name
 }
 
+// Kind returns the location's kind (plant, area, line, section).
 func (l *Location) Kind() LocationKind {
 	return l.kind
 }
 
+// ParentCode returns the code of the parent location, or empty string if root.
 func (l *Location) ParentCode() string {
 	if l.parent == nil {
 		return ""
@@ -59,10 +68,12 @@ func (l *Location) ParentCode() string {
 	return l.parent.code
 }
 
+// Children returns the direct child locations.
 func (l *Location) Children() []*Location {
 	return l.children
 }
 
+// FindByCode searches for a location by code within this subtree.
 func (l *Location) FindByCode(code string) *Location {
 	if l.code == code {
 		return l
@@ -85,11 +96,13 @@ func (l *Location) FindByCode(code string) *Location {
 	return nil
 }
 
+// ExistsByCode reports whether a location with the given code exists in this subtree.
 func (l *Location) ExistsByCode(code string) bool {
 	location := l.FindByCode(code)
 	return location != nil
 }
 
+// IsValidLocationKind reports whether the given string is a valid LocationKind value.
 func IsValidLocationKind(kind string) bool {
 	switch LocationKind(kind) {
 	case LocationKindPlant, LocationKindArea, LocationKindLine, LocationKindSection:
@@ -99,6 +112,7 @@ func IsValidLocationKind(kind string) bool {
 	}
 }
 
+// AddChild appends a child location to this location's children list.
 func (l *Location) AddChild(location *Location) {
 	l.children = append(l.children, location)
 }

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -60,11 +60,10 @@ func (l *Location) FindByCode(code string) *Location {
 	for _, child := range l.children {
 		if child.code == code {
 			return child
-		} else {
-			locationFound := child.FindByCode(code)
-			if locationFound != nil {
-				return locationFound
-			}
+		}
+		locationFound := child.FindByCode(code)
+		if locationFound != nil {
+			return locationFound
 		}
 	}
 

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -2,8 +2,6 @@ package entity
 
 import (
 	"time"
-
-	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
 )
 
 type Location struct {
@@ -40,6 +38,9 @@ func (l *Location) Name() string {
 }
 
 func (l *Location) ParentCode() string {
+	if l.parent == nil {
+		return ""
+	}
 	return l.parent.code
 }
 
@@ -47,24 +48,30 @@ func (l *Location) Children() []*Location {
 	return l.children
 }
 
-func (l *Location) FindByCode(code string) (*Location, error) {
+func (l *Location) FindByCode(code string) *Location {
+	if l.code == code {
+		return l
+	}
+
 	if l.children == nil {
-		return nil, errors.ErrLocationNotFound
+		return nil
 	}
 
 	for _, child := range l.children {
 		if child.code == code {
-			return child, nil
+			return child
 		} else {
-			locationFound, err := child.FindByCode(code)
-			if err != nil {
-				return nil, err
-			}
-			return locationFound, nil
+			locationFound := child.FindByCode(code)
+			return locationFound
 		}
 	}
 
-	return nil, nil
+	return nil
+}
+
+func (l *Location) ExistsByLocation(code string) bool {
+	location := l.FindByCode(code)
+	return location != nil
 }
 
 func (l *Location) AddChild(location *Location) {

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -62,7 +62,9 @@ func (l *Location) FindByCode(code string) *Location {
 			return child
 		} else {
 			locationFound := child.FindByCode(code)
-			return locationFound
+			if locationFound != nil {
+				return locationFound
+			}
 		}
 	}
 

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -71,7 +71,7 @@ func (l *Location) FindByCode(code string) *Location {
 	return nil
 }
 
-func (l *Location) ExistsByLocation(code string) bool {
+func (l *Location) ExistsByCode(code string) bool {
 	location := l.FindByCode(code)
 	return location != nil
 }

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -1,0 +1,77 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
+)
+
+type Location struct {
+	code      string
+	name      string
+	parent    *Location
+	children  []*Location
+	createdAt time.Time
+	updatedAt time.Time
+}
+
+func NewLocation(code string, name string, parent *Location) *Location {
+	now := time.Now()
+	return &Location{
+		code:      code,
+		name:      name,
+		parent:    parent,
+		children:  nil,
+		createdAt: now,
+		updatedAt: now,
+	}
+}
+
+func NewRootLocation(code string, name string) *Location {
+	return NewLocation(code, name, nil)
+}
+
+func (l *Location) Code() string {
+	return l.code
+}
+
+func (l *Location) Name() string {
+	return l.name
+}
+
+func (l *Location) ParentCode() string {
+	return l.parent.code
+}
+
+func (l *Location) Children() []*Location {
+	return l.children
+}
+
+func (l *Location) FindByCode(code string) (*Location, error) {
+	if l.children == nil {
+		return nil, errors.ErrLocationNotFound
+	}
+
+	for _, child := range l.children {
+		if child.code == code {
+			return child, nil
+		} else {
+			locationFound, err := child.FindByCode(code)
+			if err != nil {
+				return nil, err
+			}
+			return locationFound, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (l *Location) AddChild(location *Location) {
+	if l.children == nil {
+		l.children = make([]*Location, 1)
+		l.children[0] = location
+	} else {
+		l.children = append(l.children, location)
+	}
+}

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -14,13 +14,13 @@ const (
 )
 
 type Location struct {
+	createdAt time.Time
+	updatedAt time.Time
+	parent    *Location
+	children  []*Location
 	code      string
 	name      string
 	kind      LocationKind
-	parent    *Location
-	children  []*Location
-	createdAt time.Time
-	updatedAt time.Time
 }
 
 func NewLocation(code string, name string, kind LocationKind, parent *Location) *Location {

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -4,20 +4,31 @@ import (
 	"time"
 )
 
+type LocationKind string
+
+const (
+	LocationKindPlant   LocationKind = "PLANT"
+	LocationKindArea    LocationKind = "AREA"
+	LocationKindLine    LocationKind = "LINE"
+	LocationKindSection LocationKind = "SECTION"
+)
+
 type Location struct {
 	code      string
 	name      string
+	kind      LocationKind
 	parent    *Location
 	children  []*Location
 	createdAt time.Time
 	updatedAt time.Time
 }
 
-func NewLocation(code string, name string, parent *Location) *Location {
+func NewLocation(code string, name string, kind LocationKind, parent *Location) *Location {
 	now := time.Now()
 	return &Location{
 		code:      code,
 		name:      name,
+		kind:      kind,
 		parent:    parent,
 		children:  nil,
 		createdAt: now,
@@ -26,7 +37,7 @@ func NewLocation(code string, name string, parent *Location) *Location {
 }
 
 func NewRootLocation(code string, name string) *Location {
-	return NewLocation(code, name, nil)
+	return NewLocation(code, name, LocationKindPlant, nil)
 }
 
 func (l *Location) Code() string {
@@ -35,6 +46,10 @@ func (l *Location) Code() string {
 
 func (l *Location) Name() string {
 	return l.name
+}
+
+func (l *Location) Kind() LocationKind {
+	return l.kind
 }
 
 func (l *Location) ParentCode() string {
@@ -73,6 +88,15 @@ func (l *Location) FindByCode(code string) *Location {
 func (l *Location) ExistsByCode(code string) bool {
 	location := l.FindByCode(code)
 	return location != nil
+}
+
+func IsValidLocationKind(kind string) bool {
+	switch LocationKind(kind) {
+	case LocationKindPlant, LocationKindArea, LocationKindLine, LocationKindSection:
+		return true
+	default:
+		return false
+	}
 }
 
 func (l *Location) AddChild(location *Location) {

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -76,10 +76,5 @@ func (l *Location) ExistsByCode(code string) bool {
 }
 
 func (l *Location) AddChild(location *Location) {
-	if l.children == nil {
-		l.children = make([]*Location, 1)
-		l.children[0] = location
-	} else {
-		l.children = append(l.children, location)
-	}
+	l.children = append(l.children, location)
 }

--- a/internal/modules/organization/domain/entity/location_test.go
+++ b/internal/modules/organization/domain/entity/location_test.go
@@ -1,0 +1,138 @@
+package entity
+
+import (
+	"testing"
+)
+
+func TestNewRootLocation(t *testing.T) {
+	loc := NewRootLocation("PLANT01", "Plant One")
+
+	if loc == nil {
+		t.Fatal("Expected location, got nil")
+	}
+	if loc.Code() != "PLANT01" {
+		t.Errorf("Expected code PLANT01, got %s", loc.Code())
+	}
+	if loc.Name() != "Plant One" {
+		t.Errorf("Expected name Plant One, got %s", loc.Name())
+	}
+	if loc.Kind() != LocationKindPlant {
+		t.Errorf("Expected kind PLANT, got %s", loc.Kind())
+	}
+	if loc.ParentCode() != "" {
+		t.Errorf("Expected empty parent code, got %s", loc.ParentCode())
+	}
+	if len(loc.Children()) != 0 {
+		t.Errorf("Expected no children, got %d", len(loc.Children()))
+	}
+}
+
+func TestNewLocation(t *testing.T) {
+	root := NewRootLocation("PLANT01", "Plant One")
+	child := NewLocation("AREA01", "Area One", LocationKindArea, root)
+
+	if child.Code() != "AREA01" {
+		t.Errorf("Expected code AREA01, got %s", child.Code())
+	}
+	if child.Kind() != LocationKindArea {
+		t.Errorf("Expected kind AREA, got %s", child.Kind())
+	}
+	if child.ParentCode() != "PLANT01" {
+		t.Errorf("Expected parent code PLANT01, got %s", child.ParentCode())
+	}
+}
+
+func TestLocation_AddChild(t *testing.T) {
+	root := NewRootLocation("PLANT01", "Plant One")
+	child := NewLocation("AREA01", "Area One", LocationKindArea, root)
+	root.AddChild(child)
+
+	if len(root.Children()) != 1 {
+		t.Fatalf("Expected 1 child, got %d", len(root.Children()))
+	}
+	if root.Children()[0].Code() != "AREA01" {
+		t.Errorf("Expected child code AREA01, got %s", root.Children()[0].Code())
+	}
+}
+
+func TestLocation_FindByCode(t *testing.T) {
+	root := NewRootLocation("PLANT01", "Plant One")
+	area := NewLocation("AREA01", "Area One", LocationKindArea, root)
+	line := NewLocation("LINE01", "Line One", LocationKindLine, area)
+	root.AddChild(area)
+	area.AddChild(line)
+
+	t.Run("find root", func(t *testing.T) {
+		found := root.FindByCode("PLANT01")
+		if found == nil || found.Code() != "PLANT01" {
+			t.Error("Expected to find root")
+		}
+	})
+
+	t.Run("find direct child", func(t *testing.T) {
+		found := root.FindByCode("AREA01")
+		if found == nil || found.Code() != "AREA01" {
+			t.Error("Expected to find AREA01")
+		}
+	})
+
+	t.Run("find nested child", func(t *testing.T) {
+		found := root.FindByCode("LINE01")
+		if found == nil || found.Code() != "LINE01" {
+			t.Error("Expected to find LINE01")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		found := root.FindByCode("UNKNOWN")
+		if found != nil {
+			t.Error("Expected nil for unknown code")
+		}
+	})
+}
+
+func TestLocation_ExistsByCode(t *testing.T) {
+	root := NewRootLocation("PLANT01", "Plant One")
+	area := NewLocation("AREA01", "Area One", LocationKindArea, root)
+	root.AddChild(area)
+
+	if !root.ExistsByCode("PLANT01") {
+		t.Error("Expected PLANT01 to exist")
+	}
+	if !root.ExistsByCode("AREA01") {
+		t.Error("Expected AREA01 to exist")
+	}
+	if root.ExistsByCode("UNKNOWN") {
+		t.Error("Expected UNKNOWN to not exist")
+	}
+}
+
+func TestIsValidLocationKind(t *testing.T) {
+	tests := []struct {
+		kind  string
+		valid bool
+	}{
+		{"PLANT", true},
+		{"AREA", true},
+		{"LINE", true},
+		{"SECTION", true},
+		{"INVALID", false},
+		{"", false},
+		{"plant", false},
+	}
+
+	for _, tt := range tests {
+		got := IsValidLocationKind(tt.kind)
+		if got != tt.valid {
+			t.Errorf("IsValidLocationKind(%q) = %v, want %v", tt.kind, got, tt.valid)
+		}
+	}
+}
+
+func TestLocation_FindByCode_NoChildren(t *testing.T) {
+	root := NewRootLocation("PLANT01", "Plant One")
+	found := root.FindByCode("AREA01")
+	if found != nil {
+		t.Error("Expected nil when no children exist")
+	}
+}

--- a/internal/modules/organization/domain/errors/location_errors.go
+++ b/internal/modules/organization/domain/errors/location_errors.go
@@ -2,6 +2,7 @@ package errors
 
 import "errors"
 
+// Location domain errors.
 var (
 	ErrLocationAlreadyExists  = errors.New("location already exists")
 	ErrLocationTreeNotFound   = errors.New("location tree not found")

--- a/internal/modules/organization/domain/errors/location_errors.go
+++ b/internal/modules/organization/domain/errors/location_errors.go
@@ -7,4 +7,5 @@ var (
 	ErrLocationTreeNotFound   = errors.New("location tree not found")
 	ErrLocationNotFound       = errors.New("location not found")
 	ErrInvalidLocationCommand = errors.New("invalid location command")
+	ErrLocationHasNoParent    = errors.New("location has no parent")
 )

--- a/internal/modules/organization/domain/errors/location_errors.go
+++ b/internal/modules/organization/domain/errors/location_errors.go
@@ -1,0 +1,10 @@
+package errors
+
+import "errors"
+
+var (
+	ErrLocationAlreadyExists  = errors.New("location already exists")
+	ErrLocationTreeNotFound   = errors.New("location tree not found")
+	ErrLocationNotFound       = errors.New("location not found")
+	ErrInvalidLocationCommand = errors.New("invalid location command")
+)

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -1,11 +1,12 @@
 package http
 
 import (
+	"github.com/gofiber/fiber/v2"
+
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/usecase"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/infrastructure/dto"
-	"github.com/gofiber/fiber/v2"
 )
 
 type LocationHandler struct {

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -55,6 +55,7 @@ func (h *LocationHandler) Add(c *fiber.Ctx) error {
 	command := input.AddLocationCommand{
 		Code:       req.Code,
 		Name:       req.Name,
+		Kind:       req.Kind,
 		ParentCode: req.ParentCode,
 		RootCode:   req.RootCode,
 	}

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -68,3 +68,13 @@ func (h *LocationHandler) Add(c *fiber.Ctx) error {
 	response := dto.ToLocationResponse(location)
 	return c.Status(fiber.StatusCreated).JSON(response)
 }
+
+func (h *LocationHandler) GetAll(c *fiber.Ctx) error {
+	locations, err := usecase.NewGetAllLocationsUseCase(h.locationRepository).Execute(c.Context())
+	if err != nil {
+		return err
+	}
+
+	response := dto.ToAllLocationsResponse(locations)
+	return c.Status(fiber.StatusOK).JSON(response)
+}

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -9,16 +9,19 @@ import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/infrastructure/dto"
 )
 
+// LocationHandler handles HTTP requests for location operations.
 type LocationHandler struct {
 	locationRepository output.LocationRepository
 }
 
+// NewLocationHandler creates a new LocationHandler with the given repository.
 func NewLocationHandler(locationRepository output.LocationRepository) *LocationHandler {
 	return &LocationHandler{
 		locationRepository: locationRepository,
 	}
 }
 
+// Create handles POST requests to create a root location.
 func (h *LocationHandler) Create(c *fiber.Ctx) error {
 	var req dto.CreateLocationRootRequest
 
@@ -51,6 +54,7 @@ func (h *LocationHandler) Create(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(response)
 }
 
+// Add handles POST requests to add a child location to an existing tree.
 func (h *LocationHandler) Add(c *fiber.Ctx) error {
 	var req dto.AddLocationRequest
 
@@ -86,6 +90,7 @@ func (h *LocationHandler) Add(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(response)
 }
 
+// GetAll handles GET requests to retrieve all locations.
 func (h *LocationHandler) GetAll(c *fiber.Ctx) error {
 	locations, err := usecase.NewGetAllLocationsUseCase(h.locationRepository).Execute(c.Context())
 	if err != nil {

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -38,6 +38,32 @@ func (h *LocationHandler) Create(c *fiber.Ctx) error {
 		return err
 	}
 
-	response := dto.ToLocationRootResponse(locationRoot)
+	response := dto.ToLocationResponse(locationRoot)
+	return c.Status(fiber.StatusCreated).JSON(response)
+}
+
+func (h *LocationHandler) Add(c *fiber.Ctx) error {
+	var req dto.AddLocationRequest
+
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
+			"invalid_request",
+			"Invalid request body",
+		))
+	}
+
+	command := input.AddLocationCommand{
+		Code:       req.Code,
+		Name:       req.Name,
+		ParentCode: req.ParentCode,
+		RootCode:   req.RootCode,
+	}
+
+	location, err := usecase.NewAddLocationUseCase(h.locationRepository).Execute(c.Context(), command)
+	if err != nil {
+		return err
+	}
+
+	response := dto.ToLocationResponse(location)
 	return c.Status(fiber.StatusCreated).JSON(response)
 }

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/usecase"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/infrastructure/dto"
+	"github.com/gofiber/fiber/v2"
+)
+
+type LocationHandler struct {
+	locationRepository output.LocationRepository
+}
+
+func NewLocationHandler(locationRepository output.LocationRepository) *LocationHandler {
+	return &LocationHandler{
+		locationRepository: locationRepository,
+	}
+}
+
+func (h *LocationHandler) Create(c *fiber.Ctx) error {
+	var req dto.CreateLocationRootRequest
+
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
+			"invalid_request",
+			"Invalid request body",
+		))
+	}
+
+	command := input.CreateLocationRootCommand{
+		Code: req.Code,
+		Name: req.Name,
+	}
+
+	locationRoot, err := usecase.NewCreateLocationRootUseCase(h.locationRepository).Execute(c.Context(), command)
+	if err != nil {
+		return err
+	}
+
+	response := dto.ToLocationRootResponse(locationRoot)
+	return c.Status(fiber.StatusCreated).JSON(response)
+}

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -28,6 +28,14 @@ func (h *LocationHandler) Create(c *fiber.Ctx) error {
 		))
 	}
 
+	// Validate request
+	if err := req.Validate(); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
+			"validation_error",
+			err.Error(),
+		))
+	}
+
 	command := input.CreateLocationRootCommand{
 		Code: req.Code,
 		Name: req.Name,

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -60,6 +60,14 @@ func (h *LocationHandler) Add(c *fiber.Ctx) error {
 		))
 	}
 
+	// Validate request
+	if err := req.Validate(); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
+			"validation_error",
+			err.Error(),
+		))
+	}
+
 	command := input.AddLocationCommand{
 		Code:       req.Code,
 		Name:       req.Name,

--- a/internal/modules/organization/infrastructure/adapter/input/http/routes.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/routes.go
@@ -1,0 +1,24 @@
+package http
+
+import (
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
+	"github.com/gofiber/fiber/v2"
+)
+
+type OrganizationRoutes struct {
+	locationHandler *LocationHandler
+}
+
+func NewOrganizationRoutes(
+	locationHandler output.LocationRepository,
+) *OrganizationRoutes {
+	return &OrganizationRoutes{
+		locationHandler: NewLocationHandler(locationHandler),
+	}
+}
+
+func (o *OrganizationRoutes) SetupRoutes(app *fiber.App) {
+	locationRoutes := app.Group("/v1/api/organization/locations")
+
+	locationRoutes.Post("/", o.locationHandler.Create)
+}

--- a/internal/modules/organization/infrastructure/adapter/input/http/routes.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/routes.go
@@ -22,4 +22,5 @@ func (o *OrganizationRoutes) SetupRoutes(app *fiber.App) {
 
 	locationRoutes.Post("/", o.locationHandler.Create)
 	locationRoutes.Post("/add", o.locationHandler.Add)
+	locationRoutes.Get("/", o.locationHandler.GetAll)
 }

--- a/internal/modules/organization/infrastructure/adapter/input/http/routes.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/routes.go
@@ -1,8 +1,9 @@
 package http
 
 import (
-	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 	"github.com/gofiber/fiber/v2"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 )
 
 type OrganizationRoutes struct {

--- a/internal/modules/organization/infrastructure/adapter/input/http/routes.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/routes.go
@@ -21,4 +21,5 @@ func (o *OrganizationRoutes) SetupRoutes(app *fiber.App) {
 	locationRoutes := app.Group("/v1/api/organization/locations")
 
 	locationRoutes.Post("/", o.locationHandler.Create)
+	locationRoutes.Post("/add", o.locationHandler.Add)
 }

--- a/internal/modules/organization/infrastructure/adapter/input/http/routes.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/routes.go
@@ -6,10 +6,12 @@ import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 )
 
+// OrganizationRoutes registers HTTP routes for the organization module.
 type OrganizationRoutes struct {
 	locationHandler *LocationHandler
 }
 
+// NewOrganizationRoutes creates a new OrganizationRoutes with the given location repository.
 func NewOrganizationRoutes(
 	locationHandler output.LocationRepository,
 ) *OrganizationRoutes {
@@ -18,6 +20,7 @@ func NewOrganizationRoutes(
 	}
 }
 
+// SetupRoutes registers all organization routes on the given Fiber app.
 func (o *OrganizationRoutes) SetupRoutes(app *fiber.App) {
 	locationRoutes := app.Group("/v1/api/organization/locations")
 

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
@@ -92,3 +92,20 @@ func (r *locationRepositoryInMemory) ExistsByCode(code string) (bool, error) {
 
 	return false, nil
 }
+
+func (r *locationRepositoryInMemory) GetAll() ([]entity.Location, error) {
+	var locations = []entity.Location{}
+
+	for _, location := range r.locations {
+		if location.ParentCode == "" {
+			locationTree, err := r.FindTree(location.Code)
+			if err != nil {
+				return nil, err
+			}
+
+			locations = append(locations, *locationTree)
+		}
+	}
+
+	return locations, nil
+}

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
@@ -1,0 +1,42 @@
+package persistence
+
+import (
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
+)
+
+type locationRepositoryInMemory struct {
+	locations []*entity.Location
+}
+
+func NewLocationRepositoryInMemory() output.LocationRepository {
+	return &locationRepositoryInMemory{
+		locations: make([]*entity.Location, 0),
+	}
+}
+
+func (r *locationRepositoryInMemory) Create(location *entity.Location) error {
+	r.locations = append(r.locations, location)
+	return nil
+}
+
+func (r *locationRepositoryInMemory) FindTree(rootCode string) (*entity.Location, error) {
+	for _, location := range r.locations {
+		if location.Code() == rootCode && location.ParentCode() == "" {
+			return location, nil
+		}
+	}
+
+	return nil, errors.ErrLocationTreeNotFound
+}
+
+func (r *locationRepositoryInMemory) FindByCode(code string) (*entity.Location, error) {
+	for _, location := range r.locations {
+		if location.Code() == code {
+			return location, nil
+		}
+	}
+
+	return nil, errors.ErrLocationNotFound
+}

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
@@ -5,6 +5,7 @@ import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
+// LocationRecord is the in-memory representation of a persisted location.
 type LocationRecord struct {
 	Code       string
 	Name       string
@@ -16,6 +17,7 @@ type locationRepositoryInMemory struct {
 	locations []LocationRecord
 }
 
+// NewLocationRepositoryInMemory creates a new in-memory LocationRepository.
 func NewLocationRepositoryInMemory() output.LocationRepository {
 	return &locationRepositoryInMemory{
 		locations: make([]LocationRecord, 0),

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
@@ -5,37 +5,86 @@ import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
+type LocationRecord struct {
+	Code       string
+	Name       string
+	ParentCode string
+}
+
 type locationRepositoryInMemory struct {
-	locations []*entity.Location
+	locations []LocationRecord
 }
 
 func NewLocationRepositoryInMemory() output.LocationRepository {
 	return &locationRepositoryInMemory{
-		locations: make([]*entity.Location, 0),
+		locations: make([]LocationRecord, 0),
 	}
 }
 
 func (r *locationRepositoryInMemory) Create(location *entity.Location) error {
-	r.locations = append(r.locations, location)
+	r.locations = append(r.locations, LocationRecord{
+		Code:       location.Code(),
+		Name:       location.Name(),
+		ParentCode: location.ParentCode(),
+	})
 	return nil
 }
 
 func (r *locationRepositoryInMemory) FindTree(rootCode string) (*entity.Location, error) {
 	for _, location := range r.locations {
-		if location.Code() == rootCode && location.ParentCode() == "" {
-			return location, nil
+		if location.Code == rootCode && location.ParentCode == "" {
+			return r.buildLocationTree(rootCode), nil
 		}
 	}
 
 	return nil, nil
 }
 
-func (r *locationRepositoryInMemory) FindByCode(code string) (*entity.Location, error) {
+func (r *locationRepositoryInMemory) buildLocationTree(rootCode string) *entity.Location {
+	var root *entity.Location
+
+	// Encontra o location raiz para este parentCode
 	for _, location := range r.locations {
-		if location.Code() == code {
-			return location, nil
+		if location.Code == rootCode {
+			root = entity.NewLocation(
+				location.Code,
+				location.Name,
+				nil,
+			)
+			break
 		}
 	}
 
-	return nil, nil
+	if root == nil {
+		return nil
+	}
+
+	// Constrói a árvore de filhos recursivamente
+	r.buildChildren(root)
+
+	return root
+}
+
+func (r *locationRepositoryInMemory) buildChildren(parent *entity.Location) {
+	for _, location := range r.locations {
+		if location.ParentCode == parent.Code() {
+			childCopy := entity.NewLocation(
+				location.Code,
+				location.Name,
+				parent,
+			)
+			r.buildChildren(childCopy)
+			parent.AddChild(childCopy)
+		}
+	}
+}
+
+func (r *locationRepositoryInMemory) ExistsByCode(code string) (bool, error) {
+	for _, location := range r.locations {
+		if location.Code == code {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
@@ -62,7 +62,6 @@ func (r *locationRepositoryInMemory) buildLocationTree(rootCode string) *entity.
 		return nil
 	}
 
-	// Constrói a árvore de filhos recursivamente
 	r.buildChildren(root)
 
 	return root

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
@@ -3,7 +3,6 @@ package persistence
 import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
-	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
 )
 
 type locationRepositoryInMemory struct {
@@ -28,7 +27,7 @@ func (r *locationRepositoryInMemory) FindTree(rootCode string) (*entity.Location
 		}
 	}
 
-	return nil, errors.ErrLocationTreeNotFound
+	return nil, nil
 }
 
 func (r *locationRepositoryInMemory) FindByCode(code string) (*entity.Location, error) {
@@ -38,5 +37,5 @@ func (r *locationRepositoryInMemory) FindByCode(code string) (*entity.Location, 
 		}
 	}
 
-	return nil, errors.ErrLocationNotFound
+	return nil, nil
 }

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
@@ -8,6 +8,7 @@ import (
 type LocationRecord struct {
 	Code       string
 	Name       string
+	Kind       string
 	ParentCode string
 }
 
@@ -25,6 +26,7 @@ func (r *locationRepositoryInMemory) Create(location *entity.Location) error {
 	r.locations = append(r.locations, LocationRecord{
 		Code:       location.Code(),
 		Name:       location.Name(),
+		Kind:       string(location.Kind()),
 		ParentCode: location.ParentCode(),
 	})
 	return nil
@@ -49,6 +51,7 @@ func (r *locationRepositoryInMemory) buildLocationTree(rootCode string) *entity.
 			root = entity.NewLocation(
 				location.Code,
 				location.Name,
+				entity.LocationKind(location.Kind),
 				nil,
 			)
 			break
@@ -71,6 +74,7 @@ func (r *locationRepositoryInMemory) buildChildren(parent *entity.Location) {
 			childCopy := entity.NewLocation(
 				location.Code,
 				location.Name,
+				entity.LocationKind(location.Kind),
 				parent,
 			)
 			r.buildChildren(childCopy)

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -1,0 +1,20 @@
+package dto
+
+import "github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+
+type CreateLocationRootRequest struct {
+	Code string `json:"code"`
+	Name string `json:"name"`
+}
+
+type LocationRootResponse struct {
+	Code string `json:"code"`
+	Name string `json:"name"`
+}
+
+func ToLocationRootResponse(locationRoot *entity.Location) LocationRootResponse {
+	return LocationRootResponse{
+		Code: locationRoot.Code(),
+		Name: locationRoot.Name(),
+	}
+}

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -6,11 +6,13 @@ import (
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
+// CreateLocationRootRequest is the request body for creating a root location.
 type CreateLocationRootRequest struct {
 	Code string `json:"code" validate:"required"`
 	Name string `json:"name" validate:"required"`
 }
 
+// Validate validates the create root location request.
 func (r *CreateLocationRootRequest) Validate() error {
 	if r.Code == "" || r.Name == "" {
 		return errors.New("code and name are required")
@@ -18,6 +20,7 @@ func (r *CreateLocationRootRequest) Validate() error {
 	return nil
 }
 
+// AddLocationRequest is the request body for adding a child location.
 type AddLocationRequest struct {
 	Code       string `json:"code" validate:"required"`
 	Name       string `json:"name" validate:"required"`
@@ -26,6 +29,7 @@ type AddLocationRequest struct {
 	RootCode   string `json:"root_code" validate:"required"`
 }
 
+// Validate validates the add location request.
 func (r *AddLocationRequest) Validate() error {
 	if r.Code == "" || r.Name == "" || r.Kind == "" || r.ParentCode == "" || r.RootCode == "" {
 		return errors.New("code, name, kind, parent_code, and root_code are required")
@@ -33,6 +37,7 @@ func (r *AddLocationRequest) Validate() error {
 	return nil
 }
 
+// LocationResponse is the JSON response for a single location node.
 type LocationResponse struct {
 	Code     string             `json:"code"`
 	Name     string             `json:"name"`
@@ -40,6 +45,7 @@ type LocationResponse struct {
 	Children []LocationResponse `json:"children,omitempty"`
 }
 
+// ToLocationResponse converts a Location entity to a LocationResponse DTO.
 func ToLocationResponse(location *entity.Location) LocationResponse {
 	children := make([]LocationResponse, len(location.Children()))
 	for i, child := range location.Children() {
@@ -54,10 +60,12 @@ func ToLocationResponse(location *entity.Location) LocationResponse {
 	}
 }
 
+// AllLocationsResponse is the JSON response for a list of location trees.
 type AllLocationsResponse struct {
 	Locations []LocationResponse `json:"locations"`
 }
 
+// ToAllLocationsResponse converts a slice of Location entities to an AllLocationsResponse DTO.
 func ToAllLocationsResponse(locations []entity.Location) AllLocationsResponse {
 	locationsResponse := make([]LocationResponse, len(locations))
 	for i, location := range locations {

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -10,6 +10,7 @@ type CreateLocationRootRequest struct {
 type AddLocationRequest struct {
 	Code       string `json:"code" validate:"required"`
 	Name       string `json:"name" validate:"required"`
+	Kind       string `json:"kind" validate:"required"`
 	ParentCode string `json:"parent_code" validate:"required"`
 	RootCode   string `json:"root_code" validate:"required"`
 }
@@ -17,6 +18,7 @@ type AddLocationRequest struct {
 type LocationResponse struct {
 	Code     string             `json:"code"`
 	Name     string             `json:"name"`
+	Kind     string             `json:"kind"`
 	Children []LocationResponse `json:"children"`
 }
 
@@ -29,6 +31,7 @@ func ToLocationResponse(location *entity.Location) LocationResponse {
 	return LocationResponse{
 		Code:     location.Code(),
 		Name:     location.Name(),
+		Kind:     string(location.Kind()),
 		Children: children,
 	}
 }

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -1,10 +1,21 @@
 package dto
 
-import "github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+import (
+	"errors"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+)
 
 type CreateLocationRootRequest struct {
 	Code string `json:"code" validate:"required"`
 	Name string `json:"name" validate:"required"`
+}
+
+func (r *CreateLocationRootRequest) Validate() error {
+	if r.Code == "" || r.Name == "" {
+		return errors.New("code and name are required")
+	}
+	return nil
 }
 
 type AddLocationRequest struct {

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -35,3 +35,17 @@ func ToLocationResponse(location *entity.Location) LocationResponse {
 		Children: children,
 	}
 }
+
+type AllLocationsResponse struct {
+	Locations []LocationResponse `json:"locations"`
+}
+
+func ToAllLocationsResponse(locations []entity.Location) AllLocationsResponse {
+	locationsResponse := make([]LocationResponse, len(locations))
+	for i, location := range locations {
+		locationsResponse[i] = ToLocationResponse(&location)
+	}
+	return AllLocationsResponse{
+		Locations: locationsResponse,
+	}
+}

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -3,18 +3,32 @@ package dto
 import "github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 
 type CreateLocationRootRequest struct {
-	Code string `json:"code"`
-	Name string `json:"name"`
+	Code string `json:"code" validate:"required"`
+	Name string `json:"name" validate:"required"`
 }
 
-type LocationRootResponse struct {
-	Code string `json:"code"`
-	Name string `json:"name"`
+type AddLocationRequest struct {
+	Code       string `json:"code" validate:"required"`
+	Name       string `json:"name" validate:"required"`
+	ParentCode string `json:"parent_code" validate:"required"`
+	RootCode   string `json:"root_code" validate:"required"`
 }
 
-func ToLocationRootResponse(locationRoot *entity.Location) LocationRootResponse {
-	return LocationRootResponse{
-		Code: locationRoot.Code(),
-		Name: locationRoot.Name(),
+type LocationResponse struct {
+	Code     string             `json:"code"`
+	Name     string             `json:"name"`
+	Children []LocationResponse `json:"children"`
+}
+
+func ToLocationResponse(location *entity.Location) LocationResponse {
+	children := make([]LocationResponse, len(location.Children()))
+	for i, child := range location.Children() {
+		children[i] = ToLocationResponse(child)
+	}
+
+	return LocationResponse{
+		Code:     location.Code(),
+		Name:     location.Name(),
+		Children: children,
 	}
 }

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -26,6 +26,13 @@ type AddLocationRequest struct {
 	RootCode   string `json:"root_code" validate:"required"`
 }
 
+func (r *AddLocationRequest) Validate() error {
+	if r.Code == "" || r.Name == "" || r.Kind == "" || r.ParentCode == "" || r.RootCode == "" {
+		return errors.New("code, name, kind, parent_code, and root_code are required")
+	}
+	return nil
+}
+
 type LocationResponse struct {
 	Code     string             `json:"code"`
 	Name     string             `json:"name"`

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -37,7 +37,7 @@ type LocationResponse struct {
 	Code     string             `json:"code"`
 	Name     string             `json:"name"`
 	Kind     string             `json:"kind"`
-	Children []LocationResponse `json:"children"`
+	Children []LocationResponse `json:"children,omitempty"`
 }
 
 func ToLocationResponse(location *entity.Location) LocationResponse {

--- a/internal/shared/infrastructure/http/server/fiber_server.go
+++ b/internal/shared/infrastructure/http/server/fiber_server.go
@@ -161,7 +161,7 @@ func (s *FiberServer) Shutdown() error {
 	return s.app.Shutdown()
 }
 
-// Health adds a health check endpoint
+// AddHealthCheck registers a health check endpoint at /health.
 func (s *FiberServer) AddHealthCheck() {
 	s.app.Get("/health", func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{


### PR DESCRIPTION
## Summary

Introduces the **Organization module** location tree feature into the MES, enabling hierarchical modeling of a plant's physical structure (Plant → Area → Line → Section). Also includes the full migration of the CI linting pipeline from golangci-lint v1 to v2.

## What changed

### Organization module — Location domain

Implements a recursive location tree following the project's hexagonal architecture:

- **Domain** (`entity.Location`) — tree node with `code`, `name`, `kind` (PLANT / AREA / LINE / SECTION), parent/child relationships, and `FindByCode` / `ExistsByCode` traversal methods
- **Application** — input ports (`CreateLocationRootUseCase`, `AddLocationUseCase`, `GetAllLocationsUseCase`) with command types and full validation
- **Output port** (`LocationRepository`) — `Create`, `FindTree`, `ExistsByCode`, `GetAll`
- **In-memory adapter** — recursive tree builder from a flat record store
- **HTTP adapter** — `POST /locations` (root), `POST /locations/child` (subtree), `GET /locations` with tree DTOs (`omitempty` on children)

### Tests

Added unit tests for the location entity (`TestNewRootLocation`, `TestLocation_FindByCode`, `TestIsValidLocationKind`, …) and all three use cases to restore coverage above the 85% threshold.

### golangci-lint v1 → v2 migration

- Migrated `.golangci.yml` to v2 schema (`linters.settings`, `linters.exclusions.rules`, `formatters` section)
- Upgraded CI action from `golangci-lint-action@v6` → `@v7` with pinned version `v2.0.2`
- Suppressed two gosec false positives (`G117` on config secret field, `G706` on log statement using `%q`)
- Fixed `revive` exported-comment violations and `govet/fieldalignment` on the Location struct

## Architecture notes

Follows the project's golden rules:
- Location references its parent by **code** (weak reference), never a direct pointer stored externally
- Business logic is fully tested; HTTP handlers are not (per project convention)
- In-memory repository is the only persistence adapter at this stage