### PR TITLE
feat: Add ShiftPattern to Organization and shiftPatternID to Location

### DIFF
--- a/api/bruno/Usermes/.gitignore
+++ b/api/bruno/Usermes/.gitignore
@@ -1,0 +1,9 @@
+# Secrets
+.env*
+
+# Dependencies
+node_modules
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/api/bruno/Usermes/environments/Local.yml
+++ b/api/bruno/Usermes/environments/Local.yml
@@ -1,0 +1,4 @@
+name: Local
+variables:
+  - name: baseURL
+    value: http://localhost:3001

--- a/api/bruno/Usermes/iam/folder.yml
+++ b/api/bruno/Usermes/iam/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: iam
+  type: folder
+  seq: 1
+
+request:
+  auth: inherit

--- a/api/bruno/Usermes/iam/locations/Add Child Location.yml
+++ b/api/bruno/Usermes/iam/locations/Add Child Location.yml
@@ -5,7 +5,7 @@ info:
 
 http:
   method: POST
-  url: http://localhost:3001/v1/api/organization/locations/add
+  url: "{{baseURL}}/v1/api/organization/locations/add"
   headers:
     - name: Content-Type
       value: application/json

--- a/api/bruno/Usermes/iam/locations/Add Child Location.yml
+++ b/api/bruno/Usermes/iam/locations/Add Child Location.yml
@@ -1,0 +1,30 @@
+info:
+  name: Add Child Location
+  type: http
+  seq: 3
+
+http:
+  method: POST
+  url: http://localhost:3001/v1/api/organization/locations/add
+  headers:
+    - name: Content-Type
+      value: application/json
+    - name: Accept
+      value: application/json
+  body:
+    type: json
+    data: |-
+      {
+        "code": "AREA-01",
+        "name": "Area 01",
+        "kind": "AREA",
+        "parent_code": "PLANT-01",
+        "root_code": "PLANT-01"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/api/bruno/Usermes/iam/locations/Create Root Location.yml
+++ b/api/bruno/Usermes/iam/locations/Create Root Location.yml
@@ -1,0 +1,27 @@
+info:
+  name: Create Root Location
+  type: http
+  seq: 2
+
+http:
+  method: POST
+  url: http://localhost:3001/v1/api/organization/locations/
+  headers:
+    - name: Content-Type
+      value: application/json
+    - name: Accept
+      value: application/json
+  body:
+    type: json
+    data: |-
+      {
+        "code": "PLANT-01",
+        "name": "Plant 01"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/api/bruno/Usermes/iam/locations/Get All Locations.yml
+++ b/api/bruno/Usermes/iam/locations/Get All Locations.yml
@@ -1,0 +1,18 @@
+info:
+  name: Get All Locations
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: $baseURL/v1/api/organization/locations/
+  headers:
+    - name: Accept
+      value: application/json
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/api/bruno/Usermes/iam/locations/Get Location by Code.yml
+++ b/api/bruno/Usermes/iam/locations/Get Location by Code.yml
@@ -1,0 +1,18 @@
+info:
+  name: Get Location by Code
+  type: http
+  seq: 4
+
+http:
+  method: GET
+  url: "{{baseURL}}/v1/api/organization/locations/PLANT-01"
+  headers:
+    - name: Accept
+      value: application/json
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/api/bruno/Usermes/iam/locations/folder.yml
+++ b/api/bruno/Usermes/iam/locations/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: locations
+  type: folder
+  seq: 2
+
+request:
+  auth: inherit

--- a/api/bruno/Usermes/iam/users/Register user.yml
+++ b/api/bruno/Usermes/iam/users/Register user.yml
@@ -1,0 +1,29 @@
+info:
+  name: Register user
+  type: http
+  seq: 1
+
+http:
+  method: POST
+  url: http://localhost:3001/v1/api/iam/users/register
+  headers:
+    - name: Content-Type
+      value: application/json
+    - name: Accept
+      value: application/json
+  body:
+    type: json
+    data: |-
+      {
+        "name": "David",
+        "username": "dvd",
+        "password": "test1234",
+        "email": "dvd@test.com"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/api/bruno/Usermes/iam/users/folder.yml
+++ b/api/bruno/Usermes/iam/users/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: users
+  type: folder
+  seq: 1
+
+request:
+  auth: inherit

--- a/api/bruno/Usermes/opencollection.yml
+++ b/api/bruno/Usermes/opencollection.yml
@@ -1,0 +1,10 @@
+opencollection: 1.0.0
+
+info:
+  name: Usermes
+bundled: false
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git

--- a/api/bruno/Usermes/production/folder.yml
+++ b/api/bruno/Usermes/production/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: production
+  type: folder
+  seq: 2
+
+request:
+  auth: inherit

--- a/api/bruno/Usermes/production/resources/Create resources.yml
+++ b/api/bruno/Usermes/production/resources/Create resources.yml
@@ -6,15 +6,15 @@ info:
 http:
   method: POST
   url: "{{baseURL}}/v1/api/production/locations/:location_code/resources/"
-  params:
-    - name: location_code
-      value: PLANT-01
-      type: path
   headers:
     - name: Content-Type
       value: application/json
     - name: Accept
       value: application/json
+  params:
+    - name: location_code
+      value: PLANT-01
+      type: path
   body:
     type: json
     data: |-

--- a/api/bruno/Usermes/production/resources/Create resources.yml
+++ b/api/bruno/Usermes/production/resources/Create resources.yml
@@ -1,11 +1,15 @@
 info:
-  name: Create Root Location
+  name: Create resources
   type: http
-  seq: 2
+  seq: 1
 
 http:
   method: POST
-  url: "{{baseURL}}/v1/api/organization/locations/"
+  url: "{{baseURL}}/v1/api/production/locations/:location_code/resources/"
+  params:
+    - name: location_code
+      value: PLANT-01
+      type: path
   headers:
     - name: Content-Type
       value: application/json
@@ -15,8 +19,11 @@ http:
     type: json
     data: |-
       {
-        "code": "PLANT-01",
-        "name": "Plant 01"
+        "code": "RES-01",
+        "type": "MACHINE",
+        "stop_factor": 0,
+        "shift_id": null,
+        "tags": []
       }
   auth: inherit
 

--- a/api/bruno/Usermes/production/resources/folder.yml
+++ b/api/bruno/Usermes/production/resources/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: resources
+  type: folder
+  seq: 1
+
+request:
+  auth: inherit

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,7 +72,7 @@ func main() {
 	httpServer.RegisterRoutes(iamRoutes.SetupRoutes)
 
 	// Organization module routes
-	organizationRoutes := organizationhttp.NewOrganizationRoutes(locationRepository)
+	organizationRoutes := organizationhttp.NewOrganizationRoutes(locationRepository, shiftPatternRepository)
 	httpServer.RegisterRoutes(organizationRoutes.SetupRoutes)
 
 	// Production module routes

--- a/internal/modules/organization/application/port/input/add_location_use_case.go
+++ b/internal/modules/organization/application/port/input/add_location_use_case.go
@@ -3,16 +3,20 @@ package input
 import (
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
 // AddLocationCommand holds the input data for adding a location to an existing tree.
+// ShiftPatternID is optional; when nil the default seeded pattern is used.
 type AddLocationCommand struct {
-	Code       string
-	Name       string
-	Kind       string
-	ParentCode string
-	RootCode   string
+	ShiftPatternID *uuid.UUID
+	Code           string
+	Name           string
+	Kind           string
+	ParentCode     string
+	RootCode       string
 }
 
 // AddLocationUseCase defines the use case for adding a child location.

--- a/internal/modules/organization/application/port/input/create_location_root_use_case.go
+++ b/internal/modules/organization/application/port/input/create_location_root_use_case.go
@@ -3,13 +3,17 @@ package input
 import (
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
 // CreateLocationRootCommand holds the input data for creating a root location.
+// ShiftPatternID is optional; when nil the default seeded pattern is used.
 type CreateLocationRootCommand struct {
-	Code string
-	Name string
+	ShiftPatternID *uuid.UUID
+	Code           string
+	Name           string
 }
 
 // CreateLocationRootUseCase defines the use case for creating a root location.

--- a/internal/modules/organization/application/port/input/create_location_root_use_case.go
+++ b/internal/modules/organization/application/port/input/create_location_root_use_case.go
@@ -3,17 +3,14 @@ package input
 import (
 	"context"
 
-	"github.com/google/uuid"
-
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
 // CreateLocationRootCommand holds the input data for creating a root location.
-// ShiftPatternID is optional; when nil the default seeded pattern is used.
+// Plants do not carry a shift pattern — only sub-locations do.
 type CreateLocationRootCommand struct {
-	ShiftPatternID *uuid.UUID
-	Code           string
-	Name           string
+	Code string
+	Name string
 }
 
 // CreateLocationRootUseCase defines the use case for creating a root location.

--- a/internal/modules/organization/application/port/input/get_location_by_code_use_case.go
+++ b/internal/modules/organization/application/port/input/get_location_by_code_use_case.go
@@ -1,0 +1,12 @@
+package input
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+)
+
+// GetLocationByCodeUseCase defines the use case for retrieving a location tree by its root code.
+type GetLocationByCodeUseCase interface {
+	Execute(ctx context.Context, code string) (*entity.Location, error)
+}

--- a/internal/modules/organization/application/port/output/shift_pattern_repository.go
+++ b/internal/modules/organization/application/port/output/shift_pattern_repository.go
@@ -14,6 +14,10 @@ type ShiftPatternRepository interface {
 	// FindByID retrieves a shift pattern by its unique identifier.
 	FindByID(id uuid.UUID) (*entity.ShiftPattern, error)
 
+	// GetDefault returns the default shift pattern (the first seeded one).
+	// Returns ErrShiftPatternNotFound when no patterns have been seeded.
+	GetDefault() (*entity.ShiftPattern, error)
+
 	// GetAll returns all shift patterns.
 	GetAll() ([]*entity.ShiftPattern, error)
 

--- a/internal/modules/organization/application/usecase/add_location_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/add_location_use_case_impl.go
@@ -10,13 +10,18 @@ import (
 )
 
 type addLocationUseCaseImpl struct {
-	locationRepository output.LocationRepository
+	locationRepository     output.LocationRepository
+	shiftPatternRepository output.ShiftPatternRepository
 }
 
 // NewAddLocationUseCase creates a new AddLocationUseCase instance.
-func NewAddLocationUseCase(locationRepository output.LocationRepository) input.AddLocationUseCase {
+func NewAddLocationUseCase(
+	locationRepository output.LocationRepository,
+	shiftPatternRepository output.ShiftPatternRepository,
+) input.AddLocationUseCase {
 	return &addLocationUseCaseImpl{
-		locationRepository: locationRepository,
+		locationRepository:     locationRepository,
+		shiftPatternRepository: shiftPatternRepository,
 	}
 }
 
@@ -43,11 +48,17 @@ func (uc *addLocationUseCaseImpl) Execute(ctx context.Context, command input.Add
 		return nil, errors.ErrLocationNotFound
 	}
 
+	shiftPatternID, err := resolveShiftPatternID(command.ShiftPatternID, uc.shiftPatternRepository)
+	if err != nil {
+		return nil, err
+	}
+
 	location := entity.NewLocation(
 		command.Code,
 		command.Name,
 		entity.LocationKind(command.Kind),
 		parentLocation,
+		shiftPatternID,
 	)
 
 	if err := uc.locationRepository.Create(location); err != nil {

--- a/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
@@ -12,19 +12,12 @@ import (
 )
 
 type createLocationRootUseCaseImpl struct {
-	locationRepository     output.LocationRepository
-	shiftPatternRepository output.ShiftPatternRepository
+	locationRepository output.LocationRepository
 }
 
 // NewCreateLocationRootUseCase creates a new CreateLocationRootUseCase instance.
-func NewCreateLocationRootUseCase(
-	locationRepository output.LocationRepository,
-	shiftPatternRepository output.ShiftPatternRepository,
-) input.CreateLocationRootUseCase {
-	return &createLocationRootUseCaseImpl{
-		locationRepository:     locationRepository,
-		shiftPatternRepository: shiftPatternRepository,
-	}
+func NewCreateLocationRootUseCase(locationRepository output.LocationRepository) input.CreateLocationRootUseCase {
+	return &createLocationRootUseCaseImpl{locationRepository: locationRepository}
 }
 
 func (uc *createLocationRootUseCaseImpl) Execute(ctx context.Context, command input.CreateLocationRootCommand) (*entity.Location, error) {
@@ -37,12 +30,7 @@ func (uc *createLocationRootUseCaseImpl) Execute(ctx context.Context, command in
 		return nil, errors.ErrLocationAlreadyExists
 	}
 
-	shiftPatternID, err := resolveShiftPatternID(command.ShiftPatternID, uc.shiftPatternRepository)
-	if err != nil {
-		return nil, err
-	}
-
-	location := entity.NewRootLocation(command.Code, command.Name, shiftPatternID)
+	location := entity.NewRootLocation(command.Code, command.Name)
 	if err := uc.locationRepository.Create(location); err != nil {
 		return nil, err
 	}

--- a/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/create_location_root_use_case_impl.go
@@ -3,6 +3,8 @@ package usecase
 import (
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
@@ -10,15 +12,18 @@ import (
 )
 
 type createLocationRootUseCaseImpl struct {
-	locationRepository output.LocationRepository
+	locationRepository     output.LocationRepository
+	shiftPatternRepository output.ShiftPatternRepository
 }
 
 // NewCreateLocationRootUseCase creates a new CreateLocationRootUseCase instance.
 func NewCreateLocationRootUseCase(
 	locationRepository output.LocationRepository,
+	shiftPatternRepository output.ShiftPatternRepository,
 ) input.CreateLocationRootUseCase {
 	return &createLocationRootUseCaseImpl{
-		locationRepository: locationRepository,
+		locationRepository:     locationRepository,
+		shiftPatternRepository: shiftPatternRepository,
 	}
 }
 
@@ -32,13 +37,27 @@ func (uc *createLocationRootUseCaseImpl) Execute(ctx context.Context, command in
 		return nil, errors.ErrLocationAlreadyExists
 	}
 
-	location := entity.NewRootLocation(
-		command.Code,
-		command.Name,
-	)
+	shiftPatternID, err := resolveShiftPatternID(command.ShiftPatternID, uc.shiftPatternRepository)
+	if err != nil {
+		return nil, err
+	}
+
+	location := entity.NewRootLocation(command.Code, command.Name, shiftPatternID)
 	if err := uc.locationRepository.Create(location); err != nil {
 		return nil, err
 	}
 
 	return location, nil
+}
+
+// resolveShiftPatternID returns the given ID when provided, otherwise fetches the default pattern.
+func resolveShiftPatternID(id *uuid.UUID, repo output.ShiftPatternRepository) (uuid.UUID, error) {
+	if id != nil {
+		return *id, nil
+	}
+	pattern, err := repo.GetDefault()
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	return pattern.ID(), nil
 }

--- a/internal/modules/organization/application/usecase/get_location_by_code_use_case_impl.go
+++ b/internal/modules/organization/application/usecase/get_location_by_code_use_case_impl.go
@@ -1,0 +1,30 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
+)
+
+type getLocationByCodeUseCase struct {
+	locationRepo output.LocationRepository
+}
+
+// NewGetLocationByCodeUseCase creates a new GetLocationByCodeUseCase instance.
+func NewGetLocationByCodeUseCase(locationRepo output.LocationRepository) input.GetLocationByCodeUseCase {
+	return &getLocationByCodeUseCase{locationRepo: locationRepo}
+}
+
+func (uc *getLocationByCodeUseCase) Execute(ctx context.Context, code string) (*entity.Location, error) {
+	location, err := uc.locationRepo.FindTree(code)
+	if err != nil {
+		return nil, err
+	}
+	if location == nil {
+		return nil, errors.ErrLocationTreeNotFound
+	}
+	return location, nil
+}

--- a/internal/modules/organization/application/usecase/location_use_cases_test.go
+++ b/internal/modules/organization/application/usecase/location_use_cases_test.go
@@ -5,16 +5,28 @@ import (
 	"testing"
 
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/input"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/infrastructure/adapter/output/persistence"
+	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/infrastructure/seeder"
 )
+
+// seededShiftPatternRepo returns an in-memory shift pattern repo pre-loaded with the default pattern.
+func seededShiftPatternRepo(t *testing.T) output.ShiftPatternRepository {
+	t.Helper()
+	repo := persistence.NewMemoryShiftPatternRepository()
+	if err := seeder.SeedDefaultShiftPatterns(repo); err != nil {
+		t.Fatalf("failed to seed shift patterns: %v", err)
+	}
+	return repo
+}
 
 func TestCreateLocationRootUseCase_Execute(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates root location successfully", func(t *testing.T) {
 		repo := persistence.NewLocationRepositoryInMemory()
-		uc := NewCreateLocationRootUseCase(repo)
+		uc := NewCreateLocationRootUseCase(repo, seededShiftPatternRepo(t))
 
 		loc, err := uc.Execute(ctx, input.CreateLocationRootCommand{
 			Code: "PLANT01",
@@ -30,11 +42,14 @@ func TestCreateLocationRootUseCase_Execute(t *testing.T) {
 		if loc.Code() != "PLANT01" {
 			t.Errorf("Expected code PLANT01, got %s", loc.Code())
 		}
+		if loc.ShiftPatternID().String() == "00000000-0000-0000-0000-000000000000" {
+			t.Error("Expected non-zero ShiftPatternID (default should be assigned)")
+		}
 	})
 
 	t.Run("returns error when location already exists", func(t *testing.T) {
 		repo := persistence.NewLocationRepositoryInMemory()
-		uc := NewCreateLocationRootUseCase(repo)
+		uc := NewCreateLocationRootUseCase(repo, seededShiftPatternRepo(t))
 		cmd := input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"}
 
 		_, err := uc.Execute(ctx, cmd)
@@ -54,7 +69,8 @@ func TestAddLocationUseCase_Execute(t *testing.T) {
 
 	setup := func() (input.AddLocationUseCase, input.CreateLocationRootUseCase) {
 		repo := persistence.NewLocationRepositoryInMemory()
-		return NewAddLocationUseCase(repo), NewCreateLocationRootUseCase(repo)
+		spRepo := seededShiftPatternRepo(t)
+		return NewAddLocationUseCase(repo, spRepo), NewCreateLocationRootUseCase(repo, spRepo)
 	}
 
 	t.Run("adds child location successfully", func(t *testing.T) {
@@ -193,7 +209,8 @@ func TestGetAllLocationsUseCase_Execute(t *testing.T) {
 
 	t.Run("returns all root locations", func(t *testing.T) {
 		repo := persistence.NewLocationRepositoryInMemory()
-		createUC := NewCreateLocationRootUseCase(repo)
+		spRepo := seededShiftPatternRepo(t)
+		createUC := NewCreateLocationRootUseCase(repo, spRepo)
 		getAllUC := NewGetAllLocationsUseCase(repo)
 
 		_, err := createUC.Execute(ctx, input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"})

--- a/internal/modules/organization/application/usecase/location_use_cases_test.go
+++ b/internal/modules/organization/application/usecase/location_use_cases_test.go
@@ -26,7 +26,7 @@ func TestCreateLocationRootUseCase_Execute(t *testing.T) {
 
 	t.Run("creates root location successfully", func(t *testing.T) {
 		repo := persistence.NewLocationRepositoryInMemory()
-		uc := NewCreateLocationRootUseCase(repo, seededShiftPatternRepo(t))
+		uc := NewCreateLocationRootUseCase(repo)
 
 		loc, err := uc.Execute(ctx, input.CreateLocationRootCommand{
 			Code: "PLANT01",
@@ -42,14 +42,15 @@ func TestCreateLocationRootUseCase_Execute(t *testing.T) {
 		if loc.Code() != "PLANT01" {
 			t.Errorf("Expected code PLANT01, got %s", loc.Code())
 		}
-		if loc.ShiftPatternID().String() == "00000000-0000-0000-0000-000000000000" {
-			t.Error("Expected non-zero ShiftPatternID (default should be assigned)")
+		// Plants have no shift pattern
+		if loc.ShiftPatternID().String() != "00000000-0000-0000-0000-000000000000" {
+			t.Error("Expected zero ShiftPatternID for plant location")
 		}
 	})
 
 	t.Run("returns error when location already exists", func(t *testing.T) {
 		repo := persistence.NewLocationRepositoryInMemory()
-		uc := NewCreateLocationRootUseCase(repo, seededShiftPatternRepo(t))
+		uc := NewCreateLocationRootUseCase(repo)
 		cmd := input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"}
 
 		_, err := uc.Execute(ctx, cmd)
@@ -69,8 +70,7 @@ func TestAddLocationUseCase_Execute(t *testing.T) {
 
 	setup := func() (input.AddLocationUseCase, input.CreateLocationRootUseCase) {
 		repo := persistence.NewLocationRepositoryInMemory()
-		spRepo := seededShiftPatternRepo(t)
-		return NewAddLocationUseCase(repo, spRepo), NewCreateLocationRootUseCase(repo, spRepo)
+		return NewAddLocationUseCase(repo, seededShiftPatternRepo(t)), NewCreateLocationRootUseCase(repo)
 	}
 
 	t.Run("adds child location successfully", func(t *testing.T) {
@@ -209,8 +209,7 @@ func TestGetAllLocationsUseCase_Execute(t *testing.T) {
 
 	t.Run("returns all root locations", func(t *testing.T) {
 		repo := persistence.NewLocationRepositoryInMemory()
-		spRepo := seededShiftPatternRepo(t)
-		createUC := NewCreateLocationRootUseCase(repo, spRepo)
+		createUC := NewCreateLocationRootUseCase(repo)
 		getAllUC := NewGetAllLocationsUseCase(repo)
 
 		_, err := createUC.Execute(ctx, input.CreateLocationRootCommand{Code: "PLANT01", Name: "Plant One"})

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -45,8 +45,9 @@ func NewLocation(code string, name string, kind LocationKind, parent *Location, 
 }
 
 // NewRootLocation creates a new root Location (plant level) with no parent.
-func NewRootLocation(code string, name string, shiftPatternID uuid.UUID) *Location {
-	return NewLocation(code, name, LocationKindPlant, nil, shiftPatternID)
+// Plants do not operate shifts, so no shift pattern is assigned.
+func NewRootLocation(code string, name string) *Location {
+	return NewLocation(code, name, LocationKindPlant, nil, uuid.UUID{})
 }
 
 // Code returns the location's unique code.

--- a/internal/modules/organization/domain/entity/location.go
+++ b/internal/modules/organization/domain/entity/location.go
@@ -2,6 +2,8 @@ package entity
 
 import (
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // LocationKind represents the type of a location in the organization hierarchy.
@@ -17,32 +19,34 @@ const (
 
 // Location represents a node in the organization location tree.
 type Location struct {
-	createdAt time.Time
-	updatedAt time.Time
-	parent    *Location
-	code      string
-	name      string
-	kind      LocationKind
-	children  []*Location
+	createdAt      time.Time
+	updatedAt      time.Time
+	parent         *Location
+	code           string
+	name           string
+	kind           LocationKind
+	children       []*Location
+	shiftPatternID uuid.UUID
 }
 
 // NewLocation creates a new Location with the given attributes.
-func NewLocation(code string, name string, kind LocationKind, parent *Location) *Location {
+func NewLocation(code string, name string, kind LocationKind, parent *Location, shiftPatternID uuid.UUID) *Location {
 	now := time.Now()
 	return &Location{
-		code:      code,
-		name:      name,
-		kind:      kind,
-		parent:    parent,
-		children:  nil,
-		createdAt: now,
-		updatedAt: now,
+		code:           code,
+		name:           name,
+		kind:           kind,
+		parent:         parent,
+		children:       nil,
+		shiftPatternID: shiftPatternID,
+		createdAt:      now,
+		updatedAt:      now,
 	}
 }
 
 // NewRootLocation creates a new root Location (plant level) with no parent.
-func NewRootLocation(code string, name string) *Location {
-	return NewLocation(code, name, LocationKindPlant, nil)
+func NewRootLocation(code string, name string, shiftPatternID uuid.UUID) *Location {
+	return NewLocation(code, name, LocationKindPlant, nil, shiftPatternID)
 }
 
 // Code returns the location's unique code.
@@ -110,6 +114,11 @@ func IsValidLocationKind(kind string) bool {
 	default:
 		return false
 	}
+}
+
+// ShiftPatternID returns the shift pattern assigned to this location.
+func (l *Location) ShiftPatternID() uuid.UUID {
+	return l.shiftPatternID
 }
 
 // AddChild appends a child location to this location's children list.

--- a/internal/modules/organization/domain/entity/location_test.go
+++ b/internal/modules/organization/domain/entity/location_test.go
@@ -2,10 +2,12 @@ package entity
 
 import (
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestNewRootLocation(t *testing.T) {
-	loc := NewRootLocation("PLANT01", "Plant One")
+	loc := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
 
 	if loc == nil {
 		t.Fatal("Expected location, got nil")
@@ -28,8 +30,8 @@ func TestNewRootLocation(t *testing.T) {
 }
 
 func TestNewLocation(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One")
-	child := NewLocation("AREA01", "Area One", LocationKindArea, root)
+	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	child := NewLocation("AREA01", "Area One", LocationKindArea, root, uuid.UUID{})
 
 	if child.Code() != "AREA01" {
 		t.Errorf("Expected code AREA01, got %s", child.Code())
@@ -42,9 +44,18 @@ func TestNewLocation(t *testing.T) {
 	}
 }
 
+func TestNewLocation_WithShiftPattern(t *testing.T) {
+	patternID := uuid.New()
+	loc := NewRootLocation("PLANT01", "Plant One", patternID)
+
+	if loc.ShiftPatternID() != patternID {
+		t.Errorf("Expected shiftPatternID %v, got %v", patternID, loc.ShiftPatternID())
+	}
+}
+
 func TestLocation_AddChild(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One")
-	child := NewLocation("AREA01", "Area One", LocationKindArea, root)
+	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	child := NewLocation("AREA01", "Area One", LocationKindArea, root, uuid.UUID{})
 	root.AddChild(child)
 
 	if len(root.Children()) != 1 {
@@ -56,9 +67,9 @@ func TestLocation_AddChild(t *testing.T) {
 }
 
 func TestLocation_FindByCode(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One")
-	area := NewLocation("AREA01", "Area One", LocationKindArea, root)
-	line := NewLocation("LINE01", "Line One", LocationKindLine, area)
+	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	area := NewLocation("AREA01", "Area One", LocationKindArea, root, uuid.UUID{})
+	line := NewLocation("LINE01", "Line One", LocationKindLine, area, uuid.UUID{})
 	root.AddChild(area)
 	area.AddChild(line)
 
@@ -92,8 +103,8 @@ func TestLocation_FindByCode(t *testing.T) {
 }
 
 func TestLocation_ExistsByCode(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One")
-	area := NewLocation("AREA01", "Area One", LocationKindArea, root)
+	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	area := NewLocation("AREA01", "Area One", LocationKindArea, root, uuid.UUID{})
 	root.AddChild(area)
 
 	if !root.ExistsByCode("PLANT01") {
@@ -130,7 +141,7 @@ func TestIsValidLocationKind(t *testing.T) {
 }
 
 func TestLocation_FindByCode_NoChildren(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One")
+	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
 	found := root.FindByCode("AREA01")
 	if found != nil {
 		t.Error("Expected nil when no children exist")

--- a/internal/modules/organization/domain/entity/location_test.go
+++ b/internal/modules/organization/domain/entity/location_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewRootLocation(t *testing.T) {
-	loc := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	loc := NewRootLocation("PLANT01", "Plant One")
 
 	if loc == nil {
 		t.Fatal("Expected location, got nil")
@@ -30,7 +30,7 @@ func TestNewRootLocation(t *testing.T) {
 }
 
 func TestNewLocation(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	root := NewRootLocation("PLANT01", "Plant One")
 	child := NewLocation("AREA01", "Area One", LocationKindArea, root, uuid.UUID{})
 
 	if child.Code() != "AREA01" {
@@ -46,15 +46,20 @@ func TestNewLocation(t *testing.T) {
 
 func TestNewLocation_WithShiftPattern(t *testing.T) {
 	patternID := uuid.New()
-	loc := NewRootLocation("PLANT01", "Plant One", patternID)
+	root := NewRootLocation("PLANT01", "Plant One")
+	area := NewLocation("AREA01", "Area One", LocationKindArea, root, patternID)
 
-	if loc.ShiftPatternID() != patternID {
-		t.Errorf("Expected shiftPatternID %v, got %v", patternID, loc.ShiftPatternID())
+	if area.ShiftPatternID() != patternID {
+		t.Errorf("Expected shiftPatternID %v, got %v", patternID, area.ShiftPatternID())
+	}
+	// Plant should have zero shift pattern ID
+	if root.ShiftPatternID() != (uuid.UUID{}) {
+		t.Error("Expected zero ShiftPatternID for plant")
 	}
 }
 
 func TestLocation_AddChild(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	root := NewRootLocation("PLANT01", "Plant One")
 	child := NewLocation("AREA01", "Area One", LocationKindArea, root, uuid.UUID{})
 	root.AddChild(child)
 
@@ -67,7 +72,7 @@ func TestLocation_AddChild(t *testing.T) {
 }
 
 func TestLocation_FindByCode(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	root := NewRootLocation("PLANT01", "Plant One")
 	area := NewLocation("AREA01", "Area One", LocationKindArea, root, uuid.UUID{})
 	line := NewLocation("LINE01", "Line One", LocationKindLine, area, uuid.UUID{})
 	root.AddChild(area)
@@ -103,7 +108,7 @@ func TestLocation_FindByCode(t *testing.T) {
 }
 
 func TestLocation_ExistsByCode(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	root := NewRootLocation("PLANT01", "Plant One")
 	area := NewLocation("AREA01", "Area One", LocationKindArea, root, uuid.UUID{})
 	root.AddChild(area)
 
@@ -141,7 +146,7 @@ func TestIsValidLocationKind(t *testing.T) {
 }
 
 func TestLocation_FindByCode_NoChildren(t *testing.T) {
-	root := NewRootLocation("PLANT01", "Plant One", uuid.UUID{})
+	root := NewRootLocation("PLANT01", "Plant One")
 	found := root.FindByCode("AREA01")
 	if found != nil {
 		t.Error("Expected nil when no children exist")

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -37,7 +37,6 @@ func (h *LocationHandler) Create(c *fiber.Ctx) error {
 		))
 	}
 
-	// Validate request
 	if err := req.Validate(); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
 			"validation_error",
@@ -55,8 +54,7 @@ func (h *LocationHandler) Create(c *fiber.Ctx) error {
 		return err
 	}
 
-	response := dto.ToLocationResponse(locationRoot)
-	return c.Status(fiber.StatusCreated).JSON(response)
+	return c.Status(fiber.StatusCreated).JSON(dto.ToLocationResponse(locationRoot))
 }
 
 // Add handles POST requests to add a child location to an existing tree.
@@ -70,7 +68,6 @@ func (h *LocationHandler) Add(c *fiber.Ctx) error {
 		))
 	}
 
-	// Validate request
 	if err := req.Validate(); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
 			"validation_error",
@@ -91,8 +88,7 @@ func (h *LocationHandler) Add(c *fiber.Ctx) error {
 		return err
 	}
 
-	response := dto.ToLocationResponse(location)
-	return c.Status(fiber.StatusCreated).JSON(response)
+	return c.Status(fiber.StatusCreated).JSON(dto.ToLocationResponse(location))
 }
 
 // GetAll handles GET requests to retrieve all locations.
@@ -102,6 +98,5 @@ func (h *LocationHandler) GetAll(c *fiber.Ctx) error {
 		return err
 	}
 
-	response := dto.ToAllLocationsResponse(locations)
-	return c.Status(fiber.StatusOK).JSON(response)
+	return c.Status(fiber.StatusOK).JSON(dto.ToAllLocationsResponse(locations))
 }

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -11,13 +11,18 @@ import (
 
 // LocationHandler handles HTTP requests for location operations.
 type LocationHandler struct {
-	locationRepository output.LocationRepository
+	locationRepository     output.LocationRepository
+	shiftPatternRepository output.ShiftPatternRepository
 }
 
-// NewLocationHandler creates a new LocationHandler with the given repository.
-func NewLocationHandler(locationRepository output.LocationRepository) *LocationHandler {
+// NewLocationHandler creates a new LocationHandler with the given repositories.
+func NewLocationHandler(
+	locationRepository output.LocationRepository,
+	shiftPatternRepository output.ShiftPatternRepository,
+) *LocationHandler {
 	return &LocationHandler{
-		locationRepository: locationRepository,
+		locationRepository:     locationRepository,
+		shiftPatternRepository: shiftPatternRepository,
 	}
 }
 
@@ -45,7 +50,7 @@ func (h *LocationHandler) Create(c *fiber.Ctx) error {
 		Name: req.Name,
 	}
 
-	locationRoot, err := usecase.NewCreateLocationRootUseCase(h.locationRepository).Execute(c.Context(), command)
+	locationRoot, err := usecase.NewCreateLocationRootUseCase(h.locationRepository, h.shiftPatternRepository).Execute(c.Context(), command)
 	if err != nil {
 		return err
 	}
@@ -81,7 +86,7 @@ func (h *LocationHandler) Add(c *fiber.Ctx) error {
 		RootCode:   req.RootCode,
 	}
 
-	location, err := usecase.NewAddLocationUseCase(h.locationRepository).Execute(c.Context(), command)
+	location, err := usecase.NewAddLocationUseCase(h.locationRepository, h.shiftPatternRepository).Execute(c.Context(), command)
 	if err != nil {
 		return err
 	}

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -91,6 +91,18 @@ func (h *LocationHandler) Add(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(dto.ToLocationResponse(location))
 }
 
+// GetByCode handles GET requests to retrieve a location tree by its root code.
+func (h *LocationHandler) GetByCode(c *fiber.Ctx) error {
+	code := c.Params("location_code")
+
+	location, err := usecase.NewGetLocationByCodeUseCase(h.locationRepository).Execute(c.Context(), code)
+	if err != nil {
+		return err
+	}
+
+	return c.Status(fiber.StatusOK).JSON(dto.ToLocationResponse(location))
+}
+
 // GetAll handles GET requests to retrieve all locations.
 func (h *LocationHandler) GetAll(c *fiber.Ctx) error {
 	locations, err := usecase.NewGetAllLocationsUseCase(h.locationRepository).Execute(c.Context())

--- a/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/location_handle.go
@@ -50,7 +50,7 @@ func (h *LocationHandler) Create(c *fiber.Ctx) error {
 		Name: req.Name,
 	}
 
-	locationRoot, err := usecase.NewCreateLocationRootUseCase(h.locationRepository, h.shiftPatternRepository).Execute(c.Context(), command)
+	locationRoot, err := usecase.NewCreateLocationRootUseCase(h.locationRepository).Execute(c.Context(), command)
 	if err != nil {
 		return err
 	}

--- a/internal/modules/organization/infrastructure/adapter/input/http/routes.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/routes.go
@@ -11,12 +11,13 @@ type OrganizationRoutes struct {
 	locationHandler *LocationHandler
 }
 
-// NewOrganizationRoutes creates a new OrganizationRoutes with the given location repository.
+// NewOrganizationRoutes creates a new OrganizationRoutes with the given repositories.
 func NewOrganizationRoutes(
-	locationHandler output.LocationRepository,
+	locationRepository output.LocationRepository,
+	shiftPatternRepository output.ShiftPatternRepository,
 ) *OrganizationRoutes {
 	return &OrganizationRoutes{
-		locationHandler: NewLocationHandler(locationHandler),
+		locationHandler: NewLocationHandler(locationRepository, shiftPatternRepository),
 	}
 }
 

--- a/internal/modules/organization/infrastructure/adapter/input/http/routes.go
+++ b/internal/modules/organization/infrastructure/adapter/input/http/routes.go
@@ -28,4 +28,5 @@ func (o *OrganizationRoutes) SetupRoutes(app *fiber.App) {
 	locationRoutes.Post("/", o.locationHandler.Create)
 	locationRoutes.Post("/add", o.locationHandler.Add)
 	locationRoutes.Get("/", o.locationHandler.GetAll)
+	locationRoutes.Get("/:location_code", o.locationHandler.GetByCode)
 }

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/location_repository_inmemory.go
@@ -1,16 +1,19 @@
 package persistence
 
 import (
+	"github.com/google/uuid"
+
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
 // LocationRecord is the in-memory representation of a persisted location.
 type LocationRecord struct {
-	Code       string
-	Name       string
-	Kind       string
-	ParentCode string
+	Code           string
+	Name           string
+	Kind           string
+	ParentCode     string
+	ShiftPatternID uuid.UUID
 }
 
 type locationRepositoryInMemory struct {
@@ -26,10 +29,11 @@ func NewLocationRepositoryInMemory() output.LocationRepository {
 
 func (r *locationRepositoryInMemory) Create(location *entity.Location) error {
 	r.locations = append(r.locations, LocationRecord{
-		Code:       location.Code(),
-		Name:       location.Name(),
-		Kind:       string(location.Kind()),
-		ParentCode: location.ParentCode(),
+		Code:           location.Code(),
+		Name:           location.Name(),
+		Kind:           string(location.Kind()),
+		ParentCode:     location.ParentCode(),
+		ShiftPatternID: location.ShiftPatternID(),
 	})
 	return nil
 }
@@ -55,6 +59,7 @@ func (r *locationRepositoryInMemory) buildLocationTree(rootCode string) *entity.
 				location.Name,
 				entity.LocationKind(location.Kind),
 				nil,
+				location.ShiftPatternID,
 			)
 			break
 		}
@@ -77,6 +82,7 @@ func (r *locationRepositoryInMemory) buildChildren(parent *entity.Location) {
 				location.Name,
 				entity.LocationKind(location.Kind),
 				parent,
+				location.ShiftPatternID,
 			)
 			r.buildChildren(childCopy)
 			parent.AddChild(childCopy)

--- a/internal/modules/organization/infrastructure/adapter/output/persistence/memory_shift_pattern_repository.go
+++ b/internal/modules/organization/infrastructure/adapter/output/persistence/memory_shift_pattern_repository.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/application/port/output"
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
+	domainerrors "github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/errors"
 )
 
 type memoryShiftPatternRepository struct {
@@ -30,6 +31,13 @@ func (r *memoryShiftPatternRepository) FindByID(id uuid.UUID) (*entity.ShiftPatt
 		}
 	}
 	return nil, nil
+}
+
+func (r *memoryShiftPatternRepository) GetDefault() (*entity.ShiftPattern, error) {
+	if len(r.patterns) == 0 {
+		return nil, domainerrors.ErrShiftPatternNotFound
+	}
+	return r.patterns[0], nil
 }
 
 func (r *memoryShiftPatternRepository) GetAll() ([]*entity.ShiftPattern, error) {

--- a/internal/modules/organization/infrastructure/dto/location_dto.go
+++ b/internal/modules/organization/infrastructure/dto/location_dto.go
@@ -3,6 +3,8 @@ package dto
 import (
 	"errors"
 
+	"github.com/google/uuid"
+
 	"github.com/davidgaspardev/usermes-backend/internal/modules/organization/domain/entity"
 )
 
@@ -39,10 +41,11 @@ func (r *AddLocationRequest) Validate() error {
 
 // LocationResponse is the JSON response for a single location node.
 type LocationResponse struct {
-	Code     string             `json:"code"`
-	Name     string             `json:"name"`
-	Kind     string             `json:"kind"`
-	Children []LocationResponse `json:"children,omitempty"`
+	Code           string             `json:"code"`
+	Name           string             `json:"name"`
+	Kind           string             `json:"kind"`
+	ShiftPatternID string             `json:"shift_pattern_id,omitempty"`
+	Children       []LocationResponse `json:"children,omitempty"`
 }
 
 // ToLocationResponse converts a Location entity to a LocationResponse DTO.
@@ -52,12 +55,18 @@ func ToLocationResponse(location *entity.Location) LocationResponse {
 		children[i] = ToLocationResponse(child)
 	}
 
-	return LocationResponse{
+	resp := LocationResponse{
 		Code:     location.Code(),
 		Name:     location.Name(),
 		Kind:     string(location.Kind()),
 		Children: children,
 	}
+
+	if id := location.ShiftPatternID(); id != (uuid.UUID{}) {
+		resp.ShiftPatternID = id.String()
+	}
+
+	return resp
 }
 
 // AllLocationsResponse is the JSON response for a list of location trees.

--- a/internal/modules/production/application/port/input/create_resource_use_case.go
+++ b/internal/modules/production/application/port/input/create_resource_use_case.go
@@ -4,8 +4,7 @@ import "context"
 
 // CreateResourceCommand holds the input data for creating a new resource.
 type CreateResourceCommand struct {
-	ShiftID      *string
-	PlantCode    string
+	LocationCode string
 	Code         string
 	ResourceType string
 	WhoCreated   string

--- a/internal/modules/production/application/port/input/resource_service.go
+++ b/internal/modules/production/application/port/input/resource_service.go
@@ -13,9 +13,8 @@ type ResourceService interface {
 	// Create creates a new resource
 	Create(
 		ctx context.Context,
-		plantCode string,
+		locationCode string,
 		code string,
-		shiftID *string,
 		resourceType string,
 		stopFactor int16,
 		tags []string,
@@ -25,9 +24,8 @@ type ResourceService interface {
 	Update(
 		ctx context.Context,
 		id uuid.UUID,
-		plantCode string,
+		locationCode string,
 		code string,
-		shiftID *string,
 		resourceType string,
 		stopFactor int16,
 		tags []string,
@@ -39,18 +37,15 @@ type ResourceService interface {
 	// GetByID retrieves a resource by ID
 	GetByID(ctx context.Context, id uuid.UUID) (*entity.Resource, error)
 
-	// GetByCode retrieves a resource by code within a plant
-	GetByCode(ctx context.Context, plantCode, code string) (*entity.Resource, error)
+	// GetByCode retrieves a resource by code within a location
+	GetByCode(ctx context.Context, locationCode, code string) (*entity.Resource, error)
 
-	// GetByPlant retrieves all resources for a specific plant
-	GetByPlant(ctx context.Context, plantCode string, limit, offset int) ([]*entity.Resource, error)
+	// GetByLocation retrieves all resources for a specific location
+	GetByLocation(ctx context.Context, locationCode string, limit, offset int) ([]*entity.Resource, error)
 
 	// GetAll retrieves all resources with pagination
 	GetAll(ctx context.Context, limit, offset int) ([]*entity.Resource, error)
 
 	// GetByType retrieves all resources of a specific type
 	GetByType(ctx context.Context, resourceType string, limit, offset int) ([]*entity.Resource, error)
-
-	// GetByShiftID retrieves all resources assigned to a specific shift
-	GetByShiftID(ctx context.Context, shiftID string, limit, offset int) ([]*entity.Resource, error)
 }

--- a/internal/modules/production/application/port/output/resource_repository.go
+++ b/internal/modules/production/application/port/output/resource_repository.go
@@ -35,7 +35,4 @@ type ResourceRepository interface {
 
 	// FindByType retrieves all resources of a specific type
 	FindByType(ctx context.Context, resourceType string, limit, offset int) ([]*entity.Resource, error)
-
-	// FindByShiftID retrieves all resources assigned to a specific shift
-	FindByShiftID(ctx context.Context, shiftID string, limit, offset int) ([]*entity.Resource, error)
 }

--- a/internal/modules/production/application/usecase/create_resource_use_case_impl.go
+++ b/internal/modules/production/application/usecase/create_resource_use_case_impl.go
@@ -33,16 +33,15 @@ func (u *createResourceUseCaseImpl) Execute(ctx context.Context, command *input.
 	}
 
 	resource := entity.NewResource(
-		command.PlantCode,
+		command.LocationCode,
 		command.Code,
-		command.ShiftID,
 		command.ResourceType,
 		command.StopFactor,
 		command.Tags,
 	)
 	event := entity.NewEventResourceCreated(
 		resource.Code(),
-		*command.ShiftID,
+		"",
 		command.WhoCreated,
 	)
 

--- a/internal/modules/production/application/usecase/create_resource_use_case_impl_test.go
+++ b/internal/modules/production/application/usecase/create_resource_use_case_impl_test.go
@@ -41,9 +41,6 @@ func (r *stubResourceRepo) FindAll(_ context.Context, _, _ int) ([]*entity.Resou
 func (r *stubResourceRepo) FindByType(_ context.Context, _ string, _, _ int) ([]*entity.Resource, error) {
 	return nil, nil
 }
-func (r *stubResourceRepo) FindByShiftID(_ context.Context, _ string, _, _ int) ([]*entity.Resource, error) {
-	return nil, nil
-}
 
 // --- stub event repository ---
 
@@ -58,11 +55,9 @@ func (r *stubEventRepo) UpdateCurrent(_ *entity.Event) error                 { r
 // --- helpers ---
 
 func validCommand() *input.CreateResourceCommand {
-	shiftID := "shift-001"
 	return &input.CreateResourceCommand{
-		PlantCode:    "SP01",
+		LocationCode: "PLANT-01",
 		Code:         "MACHINE-001",
-		ShiftID:      &shiftID,
 		ResourceType: "CNC",
 		StopFactor:   10,
 		WhoCreated:   "user-001",

--- a/internal/modules/production/application/usecase/resource_service_impl.go
+++ b/internal/modules/production/application/usecase/resource_service_impl.go
@@ -27,47 +27,38 @@ func NewResourceService(repository output.ResourceRepository) input.ResourceServ
 // Create creates a new resource
 func (s *ResourceServiceImpl) Create(
 	ctx context.Context,
-	plantCode string,
+	locationCode string,
 	code string,
-	shiftID *string,
 	resourceType string,
 	stopFactor int16,
 	tags []string,
 ) (*entity.Resource, error) {
-	// Validate plant code
-	plantCode = strings.ToUpper(strings.TrimSpace(plantCode))
-	if plantCode == "" {
+	locationCode = strings.ToUpper(strings.TrimSpace(locationCode))
+	if locationCode == "" {
 		return nil, errors.ErrInvalidCode
 	}
 
-	// Validate code
 	if err := s.validateCode(code); err != nil {
 		return nil, err
 	}
 
-	// Validate resource type
 	if err := s.validateResourceType(resourceType); err != nil {
 		return nil, err
 	}
 
-	// Validate stop factor
 	if err := s.validateStopFactor(stopFactor); err != nil {
 		return nil, err
 	}
 
-	// Normalize code
 	code = strings.ToUpper(strings.TrimSpace(code))
 
-	// Check if code already exists in this plant
 	existing, err := s.repository.FindByCode(ctx, code)
-	if err == nil && existing != nil && existing.PlantCode() == plantCode {
+	if err == nil && existing != nil && existing.LocationCode() == locationCode {
 		return nil, errors.ErrResourceCodeAlreadyExists
 	}
 
-	// Create resource
-	resource := entity.NewResource(plantCode, code, shiftID, resourceType, stopFactor, tags)
+	resource := entity.NewResource(locationCode, code, resourceType, stopFactor, tags)
 
-	// Save resource
 	if err := s.repository.Save(ctx, resource); err != nil {
 		return nil, err
 	}
@@ -79,50 +70,41 @@ func (s *ResourceServiceImpl) Create(
 func (s *ResourceServiceImpl) Update(
 	ctx context.Context,
 	id uuid.UUID,
-	plantCode string,
+	locationCode string,
 	code string,
-	shiftID *string,
 	resourceType string,
 	stopFactor int16,
 	tags []string,
 ) (*entity.Resource, error) {
-	// Validate plant code
-	plantCode = strings.ToUpper(strings.TrimSpace(plantCode))
-	if plantCode == "" {
+	locationCode = strings.ToUpper(strings.TrimSpace(locationCode))
+	if locationCode == "" {
 		return nil, errors.ErrInvalidCode
 	}
 
-	// Validate code
 	if err := s.validateCode(code); err != nil {
 		return nil, err
 	}
 
-	// Validate resource type
 	if err := s.validateResourceType(resourceType); err != nil {
 		return nil, err
 	}
 
-	// Validate stop factor
 	if err := s.validateStopFactor(stopFactor); err != nil {
 		return nil, err
 	}
 
-	// Normalize code
 	code = strings.ToUpper(strings.TrimSpace(code))
 
-	// Find existing resource
 	resource, err := s.repository.FindByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	// Update resource (including plant code if changed)
-	if resource.PlantCode() != plantCode {
-		resource.UpdatePlantCode(plantCode)
+	if resource.LocationCode() != locationCode {
+		resource.UpdateLocationCode(locationCode)
 	}
-	resource.Update(code, shiftID, resourceType, stopFactor, tags)
+	resource.Update(code, resourceType, stopFactor, tags)
 
-	// Save changes
 	if err := s.repository.Update(ctx, resource); err != nil {
 		return nil, err
 	}
@@ -132,13 +114,10 @@ func (s *ResourceServiceImpl) Update(
 
 // Delete deletes a resource by ID
 func (s *ResourceServiceImpl) Delete(ctx context.Context, id uuid.UUID) error {
-	// Check if resource exists
 	_, err := s.repository.FindByID(ctx, id)
 	if err != nil {
 		return err
 	}
-
-	// Delete resource
 	return s.repository.Delete(ctx, id)
 }
 
@@ -147,9 +126,9 @@ func (s *ResourceServiceImpl) GetByID(ctx context.Context, id uuid.UUID) (*entit
 	return s.repository.FindByID(ctx, id)
 }
 
-// GetByCode retrieves a resource by code within a plant
-func (s *ResourceServiceImpl) GetByCode(ctx context.Context, plantCode, code string) (*entity.Resource, error) {
-	plantCode = strings.ToUpper(strings.TrimSpace(plantCode))
+// GetByCode retrieves a resource by code within a location
+func (s *ResourceServiceImpl) GetByCode(ctx context.Context, locationCode, code string) (*entity.Resource, error) {
+	locationCode = strings.ToUpper(strings.TrimSpace(locationCode))
 	code = strings.ToUpper(strings.TrimSpace(code))
 
 	resource, err := s.repository.FindByCode(ctx, code)
@@ -157,32 +136,30 @@ func (s *ResourceServiceImpl) GetByCode(ctx context.Context, plantCode, code str
 		return nil, err
 	}
 
-	// Verify resource belongs to the specified plant
-	if resource.PlantCode() != plantCode {
+	if resource.LocationCode() != locationCode {
 		return nil, errors.ErrResourceNotFound
 	}
 
 	return resource, nil
 }
 
-// GetByPlant retrieves all resources for a specific plant
-func (s *ResourceServiceImpl) GetByPlant(ctx context.Context, plantCode string, limit, offset int) ([]*entity.Resource, error) {
-	plantCode = strings.ToUpper(strings.TrimSpace(plantCode))
+// GetByLocation retrieves all resources for a specific location
+func (s *ResourceServiceImpl) GetByLocation(ctx context.Context, locationCode string, limit, offset int) ([]*entity.Resource, error) {
+	locationCode = strings.ToUpper(strings.TrimSpace(locationCode))
 
 	allResources, err := s.repository.FindAll(ctx, limit, offset)
 	if err != nil {
 		return nil, err
 	}
 
-	// Filter by plant code
-	plantResources := make([]*entity.Resource, 0)
+	result := make([]*entity.Resource, 0)
 	for _, resource := range allResources {
-		if resource.PlantCode() == plantCode {
-			plantResources = append(plantResources, resource)
+		if resource.LocationCode() == locationCode {
+			result = append(result, resource)
 		}
 	}
 
-	return plantResources, nil
+	return result, nil
 }
 
 // GetAll retrieves all resources with pagination
@@ -195,36 +172,22 @@ func (s *ResourceServiceImpl) GetByType(ctx context.Context, resourceType string
 	return s.repository.FindByType(ctx, resourceType, limit, offset)
 }
 
-// GetByShiftID retrieves all resources assigned to a specific shift
-func (s *ResourceServiceImpl) GetByShiftID(ctx context.Context, shiftID string, limit, offset int) ([]*entity.Resource, error) {
-	return s.repository.FindByShiftID(ctx, shiftID, limit, offset)
-}
-
-// validateCode validates the resource code
 func (s *ResourceServiceImpl) validateCode(code string) error {
 	code = strings.TrimSpace(code)
-	if code == "" {
-		return errors.ErrInvalidCode
-	}
-	if len(code) < 2 || len(code) > 50 {
+	if code == "" || len(code) < 2 || len(code) > 50 {
 		return errors.ErrInvalidCode
 	}
 	return nil
 }
 
-// validateResourceType validates the resource type
 func (s *ResourceServiceImpl) validateResourceType(resourceType string) error {
 	resourceType = strings.TrimSpace(resourceType)
-	if resourceType == "" {
-		return errors.ErrInvalidType
-	}
-	if len(resourceType) < 2 || len(resourceType) > 50 {
+	if resourceType == "" || len(resourceType) < 2 || len(resourceType) > 50 {
 		return errors.ErrInvalidType
 	}
 	return nil
 }
 
-// validateStopFactor validates the stop factor
 func (s *ResourceServiceImpl) validateStopFactor(stopFactor int16) error {
 	if stopFactor < 0 {
 		return errors.ErrInvalidStopFactor

--- a/internal/modules/production/application/usecase/resource_service_impl_test.go
+++ b/internal/modules/production/application/usecase/resource_service_impl_test.go
@@ -30,7 +30,7 @@ func TestResourceService_Create(t *testing.T) { //nolint:gocyclo
 		resourceType := "machine"
 		stopFactor := int16(5)
 
-		resource, err := service.Create(ctx, "SP01", code, nil, resourceType, stopFactor, nil)
+		resource, err := service.Create(ctx, "PLANT-01", code, resourceType, stopFactor, nil)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -46,27 +46,8 @@ func TestResourceService_Create(t *testing.T) { //nolint:gocyclo
 		}
 	})
 
-	t.Run("with shift ID", func(t *testing.T) {
-		code := "RES002"
-		shiftID := "shift123"
-		resourceType := "tool"
-		stopFactor := int16(3)
-
-		resource, err := service.Create(ctx, "SP01", code, &shiftID, resourceType, stopFactor, nil)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-
-		if resource.ShiftID() == nil {
-			t.Fatal("Expected shiftID to be set")
-		}
-		if *resource.ShiftID() != shiftID {
-			t.Errorf("Expected shiftID %s, got %s", shiftID, *resource.ShiftID())
-		}
-	})
-
 	t.Run("invalid code - empty", func(t *testing.T) {
-		_, err := service.Create(ctx, "SP01", "", nil, "machine", 5, nil)
+		_, err := service.Create(ctx, "PLANT-01", "", "machine", 5, nil)
 		if err == nil {
 			t.Fatal("Expected error for empty code")
 		}
@@ -77,7 +58,7 @@ func TestResourceService_Create(t *testing.T) { //nolint:gocyclo
 
 	t.Run("invalid code - too long", func(t *testing.T) {
 		longCode := "THISISAVERYLONGCODETHATEXCEEDSFIFTYCHARACTERSLIMIT123456789"
-		_, err := service.Create(ctx, "SP01", longCode, nil, "machine", 5, nil)
+		_, err := service.Create(ctx, "PLANT-01", longCode, "machine", 5, nil)
 		if err == nil {
 			t.Fatal("Expected error for code too long")
 		}
@@ -87,7 +68,7 @@ func TestResourceService_Create(t *testing.T) { //nolint:gocyclo
 	})
 
 	t.Run("invalid type - empty", func(t *testing.T) {
-		_, err := service.Create(ctx, "SP01", "RES003", nil, "", 5, nil)
+		_, err := service.Create(ctx, "PLANT-01", "RES003", "", 5, nil)
 		if err == nil {
 			t.Fatal("Expected error for empty type")
 		}
@@ -98,7 +79,7 @@ func TestResourceService_Create(t *testing.T) { //nolint:gocyclo
 
 	t.Run("invalid type - too long", func(t *testing.T) {
 		longType := "THISISAVERYLONGTYPETHATEXCEEDSFIFTYCHARACTERSLIMIT1234567890"
-		_, err := service.Create(ctx, "SP01", "RES004", nil, longType, 5, nil)
+		_, err := service.Create(ctx, "PLANT-01", "RES004", longType, 5, nil)
 		if err == nil {
 			t.Fatal("Expected error for type too long")
 		}
@@ -108,7 +89,7 @@ func TestResourceService_Create(t *testing.T) { //nolint:gocyclo
 	})
 
 	t.Run("invalid stopFactor - negative", func(t *testing.T) {
-		_, err := service.Create(ctx, "SP01", "RES005", nil, "machine", -1, nil)
+		_, err := service.Create(ctx, "PLANT-01", "RES005", "machine", -1, nil)
 		if err == nil {
 			t.Fatal("Expected error for negative stopFactor")
 		}
@@ -119,14 +100,12 @@ func TestResourceService_Create(t *testing.T) { //nolint:gocyclo
 
 	t.Run("duplicate code", func(t *testing.T) {
 		code := "RES006"
-		// Create first resource
-		_, err := service.Create(ctx, "SP01", code, nil, "machine", 5, nil)
+		_, err := service.Create(ctx, "PLANT-01", code, "machine", 5, nil)
 		if err != nil {
 			t.Fatalf("Expected no error on first create, got %v", err)
 		}
 
-		// Try to create with same code
-		_, err = service.Create(ctx, "SP01", code, nil, "tool", 3, nil)
+		_, err = service.Create(ctx, "PLANT-01", code, "tool", 3, nil)
 		if err == nil {
 			t.Fatal("Expected error for duplicate code")
 		}
@@ -141,8 +120,7 @@ func TestResourceService_Update(t *testing.T) {
 	service := NewResourceService(repo)
 	ctx := context.Background()
 
-	// Create initial resource
-	initialResource, err := service.Create(ctx, "SP01", "RES100", nil, "machine", 5, nil)
+	initialResource, err := service.Create(ctx, "PLANT-01", "RES100", "machine", 5, nil)
 	if err != nil {
 		t.Fatalf("Failed to create initial resource: %v", err)
 	}
@@ -152,7 +130,7 @@ func TestResourceService_Update(t *testing.T) {
 		newType := "tool"
 		newStopFactor := int16(10)
 
-		updated, err := service.Update(ctx, initialResource.ID(), "SP01", newCode, nil, newType, newStopFactor, nil)
+		updated, err := service.Update(ctx, initialResource.ID(), "PLANT-01", newCode, newType, newStopFactor, nil)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -169,7 +147,7 @@ func TestResourceService_Update(t *testing.T) {
 	})
 
 	t.Run("update with invalid code", func(t *testing.T) {
-		_, err := service.Update(ctx, initialResource.ID(), "SP01", "", nil, "machine", 5, nil)
+		_, err := service.Update(ctx, initialResource.ID(), "PLANT-01", "", "machine", 5, nil)
 		if err == nil {
 			t.Fatal("Expected error for invalid code")
 		}
@@ -179,7 +157,7 @@ func TestResourceService_Update(t *testing.T) {
 	})
 
 	t.Run("update with invalid type", func(t *testing.T) {
-		_, err := service.Update(ctx, initialResource.ID(), "SP01", "RES103", nil, "", 5, nil)
+		_, err := service.Update(ctx, initialResource.ID(), "PLANT-01", "RES103", "", 5, nil)
 		if err == nil {
 			t.Fatal("Expected error for invalid type")
 		}
@@ -189,7 +167,7 @@ func TestResourceService_Update(t *testing.T) {
 	})
 
 	t.Run("update with invalid stopFactor", func(t *testing.T) {
-		_, err := service.Update(ctx, initialResource.ID(), "SP01", "RES104", nil, "machine", -5, nil)
+		_, err := service.Update(ctx, initialResource.ID(), "PLANT-01", "RES104", "machine", -5, nil)
 		if err == nil {
 			t.Fatal("Expected error for invalid stopFactor")
 		}
@@ -205,7 +183,7 @@ func TestResourceService_Delete(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("successful delete", func(t *testing.T) {
-		resource, err := service.Create(ctx, "SP01", "RES200", nil, "machine", 5, nil)
+		resource, err := service.Create(ctx, "PLANT-01", "RES200", "machine", 5, nil)
 		if err != nil {
 			t.Fatalf("Failed to create resource: %v", err)
 		}
@@ -215,7 +193,6 @@ func TestResourceService_Delete(t *testing.T) {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		// Verify deletion
 		_, err = service.GetByID(ctx, resource.ID())
 		if err == nil {
 			t.Error("Expected error for deleted resource")
@@ -237,7 +214,7 @@ func TestResourceService_GetByID(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("get existing resource", func(t *testing.T) {
-		created, err := service.Create(ctx, "SP01", "RES300", nil, "machine", 5, nil)
+		created, err := service.Create(ctx, "PLANT-01", "RES300", "machine", 5, nil)
 		if err != nil {
 			t.Fatalf("Failed to create resource: %v", err)
 		}
@@ -270,12 +247,12 @@ func TestResourceService_GetByCode(t *testing.T) {
 
 	t.Run("get existing resource by code", func(t *testing.T) {
 		code := "RES400"
-		created, err := service.Create(ctx, "SP01", code, nil, "machine", 5, nil)
+		created, err := service.Create(ctx, "PLANT-01", code, "machine", 5, nil)
 		if err != nil {
 			t.Fatalf("Failed to create resource: %v", err)
 		}
 
-		found, err := service.GetByCode(ctx, "SP01", code)
+		found, err := service.GetByCode(ctx, "PLANT-01", code)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -291,7 +268,7 @@ func TestResourceService_GetByCode(t *testing.T) {
 	})
 
 	t.Run("get non-existent resource by code", func(t *testing.T) {
-		_, err := service.GetByCode(ctx, "SP01", "NONEXISTENT")
+		_, err := service.GetByCode(ctx, "PLANT-01", "NONEXISTENT")
 		if err == nil {
 			t.Fatal("Expected error for non-existent resource")
 		}
@@ -303,10 +280,9 @@ func TestResourceService_GetAll(t *testing.T) {
 	service := NewResourceService(repo)
 	ctx := context.Background()
 
-	// Create multiple resources
 	for i := 0; i < 5; i++ {
 		code := "RES500" + string(rune('A'+i))
-		_, err := service.Create(ctx, "SP01", code, nil, "machine", int16(i), nil) // nolint:gosec
+		_, err := service.Create(ctx, "PLANT-01", code, "machine", int16(i), nil) // nolint:gosec
 		if err != nil {
 			t.Fatalf("Failed to create resource: %v", err)
 		}
@@ -338,14 +314,13 @@ func TestResourceService_GetByType(t *testing.T) {
 	service := NewResourceService(repo)
 	ctx := context.Background()
 
-	// Create resources with different types
-	if _, err := service.Create(ctx, "SP01", "RES600", nil, "machine", 1, nil); err != nil {
+	if _, err := service.Create(ctx, "PLANT-01", "RES600", "machine", 1, nil); err != nil {
 		t.Fatalf("Failed to create resource: %v", err)
 	}
-	if _, err := service.Create(ctx, "SP01", "RES601", nil, "machine", 2, nil); err != nil {
+	if _, err := service.Create(ctx, "PLANT-01", "RES601", "machine", 2, nil); err != nil {
 		t.Fatalf("Failed to create resource: %v", err)
 	}
-	if _, err := service.Create(ctx, "SP01", "RES602", nil, "tool", 3, nil); err != nil {
+	if _, err := service.Create(ctx, "PLANT-01", "RES602", "tool", 3, nil); err != nil {
 		t.Fatalf("Failed to create resource: %v", err)
 	}
 
@@ -370,54 +345,12 @@ func TestResourceService_GetByType(t *testing.T) {
 	})
 }
 
-func TestResourceService_GetByShiftID(t *testing.T) {
-	repo := persistence.NewMemoryResourceRepository()
-	service := NewResourceService(repo)
-	ctx := context.Background()
-
-	// Create resources with different shift IDs
-	shiftID1 := "shift001"
-	shiftID2 := "shift002"
-	if _, err := service.Create(ctx, "SP01", "RES700", &shiftID1, "machine", 1, nil); err != nil {
-		t.Fatalf("Failed to create resource: %v", err)
-	}
-	if _, err := service.Create(ctx, "SP01", "RES701", &shiftID1, "machine", 2, nil); err != nil {
-		t.Fatalf("Failed to create resource: %v", err)
-	}
-	if _, err := service.Create(ctx, "SP01", "RES702", &shiftID2, "tool", 3, nil); err != nil {
-		t.Fatalf("Failed to create resource: %v", err)
-	}
-	if _, err := service.Create(ctx, "SP01", "RES703", nil, "tool", 4, nil); err != nil {
-		t.Fatalf("Failed to create resource: %v", err)
-	}
-
-	t.Run("get by existing shift ID", func(t *testing.T) {
-		resources, err := service.GetByShiftID(ctx, shiftID1, 10, 0)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if len(resources) != 2 {
-			t.Errorf("Expected 2 resources, got %d", len(resources))
-		}
-	})
-
-	t.Run("get by non-existent shift ID", func(t *testing.T) {
-		resources, err := service.GetByShiftID(ctx, "nonexistent", 10, 0)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if len(resources) != 0 {
-			t.Errorf("Expected 0 resources, got %d", len(resources))
-		}
-	})
-}
-
 func TestResourceService_UpdatedAt(t *testing.T) {
 	repo := persistence.NewMemoryResourceRepository()
 	service := NewResourceService(repo)
 	ctx := context.Background()
 
-	resource, err := service.Create(ctx, "SP01", "RES800", nil, "machine", 5, nil)
+	resource, err := service.Create(ctx, "PLANT-01", "RES800", "machine", 5, nil)
 	if err != nil {
 		t.Fatalf("Failed to create resource: %v", err)
 	}
@@ -425,10 +358,9 @@ func TestResourceService_UpdatedAt(t *testing.T) {
 	createdAt := resource.CreatedAt()
 	updatedAt := resource.UpdatedAt()
 
-	// Small delay to ensure time difference
 	time.Sleep(10 * time.Millisecond)
 
-	updated, err := service.Update(ctx, resource.ID(), "SP01", "RES801", nil, "machine", 5, nil)
+	updated, err := service.Update(ctx, resource.ID(), "PLANT-01", "RES801", "machine", 5, nil)
 	if err != nil {
 		t.Fatalf("Failed to update resource: %v", err)
 	}

--- a/internal/modules/production/domain/entity/resource.go
+++ b/internal/modules/production/domain/entity/resource.go
@@ -10,8 +10,7 @@ import (
 type Resource struct {
 	createdAt    time.Time
 	updatedAt    time.Time
-	plantCode    string
-	shiftID      *string
+	locationCode string
 	code         string
 	resourceType string
 	tags         []string
@@ -30,13 +29,12 @@ func copyStringSlice(src []string) []string {
 }
 
 // NewResource creates a new resource instance
-func NewResource(plantCode, code string, shiftID *string, resourceType string, stopFactor int16, tags []string) *Resource {
+func NewResource(locationCode, code, resourceType string, stopFactor int16, tags []string) *Resource {
 	now := time.Now()
 	return &Resource{
 		id:           uuid.New(),
-		plantCode:    plantCode,
+		locationCode: locationCode,
 		code:         code,
-		shiftID:      shiftID,
 		resourceType: resourceType,
 		stopFactor:   stopFactor,
 		tags:         copyStringSlice(tags),
@@ -48,8 +46,7 @@ func NewResource(plantCode, code string, shiftID *string, resourceType string, s
 // ReconstructResource reconstructs a resource from persistence
 func ReconstructResource(
 	id uuid.UUID,
-	plantCode, code string,
-	shiftID *string,
+	locationCode, code string,
 	resourceType string,
 	stopFactor int16,
 	tags []string,
@@ -58,9 +55,8 @@ func ReconstructResource(
 ) *Resource {
 	return &Resource{
 		id:           id,
-		plantCode:    plantCode,
+		locationCode: locationCode,
 		code:         code,
-		shiftID:      shiftID,
 		resourceType: resourceType,
 		stopFactor:   stopFactor,
 		tags:         copyStringSlice(tags),
@@ -74,19 +70,14 @@ func (r *Resource) ID() uuid.UUID {
 	return r.id
 }
 
-// PlantCode returns the plant code
-func (r *Resource) PlantCode() string {
-	return r.plantCode
+// LocationCode returns the location code
+func (r *Resource) LocationCode() string {
+	return r.locationCode
 }
 
 // Code returns the resource code
 func (r *Resource) Code() string {
 	return r.code
-}
-
-// ShiftID returns the shift ID (can be nil)
-func (r *Resource) ShiftID() *string {
-	return r.shiftID
 }
 
 // Type returns the resource type
@@ -120,12 +111,6 @@ func (r *Resource) UpdateCode(code string) {
 	r.updatedAt = time.Now()
 }
 
-// UpdateShiftID updates the shift ID
-func (r *Resource) UpdateShiftID(shiftID *string) {
-	r.shiftID = shiftID
-	r.updatedAt = time.Now()
-}
-
 // UpdateType updates the resource type
 func (r *Resource) UpdateType(resourceType string) {
 	r.resourceType = resourceType
@@ -144,18 +129,17 @@ func (r *Resource) UpdateTags(tags []string) {
 	r.updatedAt = time.Now()
 }
 
-// Update updates all mutable fields at once
-func (r *Resource) Update(code string, shiftID *string, resourceType string, stopFactor int16, tags []string) {
-	r.code = code
-	r.shiftID = shiftID
-	r.resourceType = resourceType
-	r.stopFactor = stopFactor
-	r.tags = copyStringSlice(tags)
+// UpdateLocationCode updates the location code
+func (r *Resource) UpdateLocationCode(locationCode string) {
+	r.locationCode = locationCode
 	r.updatedAt = time.Now()
 }
 
-// UpdatePlantCode updates the plant code (for migration purposes)
-func (r *Resource) UpdatePlantCode(plantCode string) {
-	r.plantCode = plantCode
+// Update updates all mutable fields at once
+func (r *Resource) Update(code, resourceType string, stopFactor int16, tags []string) {
+	r.code = code
+	r.resourceType = resourceType
+	r.stopFactor = stopFactor
+	r.tags = copyStringSlice(tags)
 	r.updatedAt = time.Now()
 }

--- a/internal/modules/production/domain/entity/resource_test.go
+++ b/internal/modules/production/domain/entity/resource_test.go
@@ -8,35 +8,24 @@ import (
 )
 
 func TestNewResource(t *testing.T) {
-	plantCode := "SP01"
+	locationCode := "PLANT-01"
 	code := "RES001"
-	shiftID := "SHIFT123"
 	resourceType := "MACHINE"
 	stopFactor := int16(5)
 	tags := []string{"tag1", "tag2"}
 
-	resource := NewResource(plantCode, code, &shiftID, resourceType, stopFactor, tags)
+	resource := NewResource(locationCode, code, resourceType, stopFactor, tags)
 
 	if resource.ID() == uuid.Nil {
 		t.Error("Resource ID should not be nil")
 	}
 
-	if resource.PlantCode() != plantCode {
-		t.Errorf("Expected plantCode '%s', got '%s'", plantCode, resource.PlantCode())
-	}
-
-	if resource.PlantCode() != plantCode {
-		t.Errorf("Expected plantCode '%s', got '%s'", plantCode, resource.PlantCode())
+	if resource.LocationCode() != locationCode {
+		t.Errorf("Expected locationCode '%s', got '%s'", locationCode, resource.LocationCode())
 	}
 
 	if resource.Code() != code {
 		t.Errorf("Expected code '%s', got '%s'", code, resource.Code())
-	}
-
-	if resource.ShiftID() == nil {
-		t.Error("ShiftID should not be nil")
-	} else if *resource.ShiftID() != shiftID {
-		t.Errorf("Expected shiftID '%s', got '%s'", shiftID, *resource.ShiftID())
 	}
 
 	if resource.Type() != resourceType {
@@ -60,20 +49,8 @@ func TestNewResource(t *testing.T) {
 	}
 }
 
-func TestNewResource_WithNilShiftID(t *testing.T) {
-	code := "RES002"
-	resourceType := "OPERATOR"
-	stopFactor := int16(0)
-
-	resource := NewResource("SP01", code, nil, resourceType, stopFactor, nil)
-
-	if resource.ShiftID() != nil {
-		t.Error("ShiftID should be nil")
-	}
-}
-
 func TestResource_UpdateCode(t *testing.T) {
-	resource := NewResource("SP01", "RES001", nil, "MACHINE", 5, nil)
+	resource := NewResource("PLANT-01", "RES001", "MACHINE", 5, nil)
 	originalUpdatedAt := resource.UpdatedAt()
 
 	time.Sleep(10 * time.Millisecond)
@@ -89,38 +66,8 @@ func TestResource_UpdateCode(t *testing.T) {
 	}
 }
 
-func TestResource_UpdateShiftID(t *testing.T) {
-	resource := NewResource("SP01", "RES001", nil, "MACHINE", 5, nil)
-	originalUpdatedAt := resource.UpdatedAt()
-
-	time.Sleep(10 * time.Millisecond)
-	newShiftID := "SHIFT456"
-	resource.UpdateShiftID(&newShiftID)
-
-	if resource.ShiftID() == nil {
-		t.Error("ShiftID should not be nil after update")
-	} else if *resource.ShiftID() != newShiftID {
-		t.Errorf("Expected shiftID '%s', got '%s'", newShiftID, *resource.ShiftID())
-	}
-
-	if !resource.UpdatedAt().After(originalUpdatedAt) {
-		t.Error("UpdatedAt should be updated")
-	}
-}
-
-func TestResource_UpdateShiftID_ToNil(t *testing.T) {
-	shiftID := "SHIFT123"
-	resource := NewResource("SP01", "RES001", &shiftID, "MACHINE", 5, nil)
-
-	resource.UpdateShiftID(nil)
-
-	if resource.ShiftID() != nil {
-		t.Error("ShiftID should be nil after update")
-	}
-}
-
 func TestResource_UpdateType(t *testing.T) {
-	resource := NewResource("SP01", "RES001", nil, "MACHINE", 5, nil)
+	resource := NewResource("PLANT-01", "RES001", "MACHINE", 5, nil)
 	originalUpdatedAt := resource.UpdatedAt()
 
 	time.Sleep(10 * time.Millisecond)
@@ -137,7 +84,7 @@ func TestResource_UpdateType(t *testing.T) {
 }
 
 func TestResource_UpdateStopFactor(t *testing.T) {
-	resource := NewResource("SP01", "RES001", nil, "MACHINE", 5, nil)
+	resource := NewResource("PLANT-01", "RES001", "MACHINE", 5, nil)
 	originalUpdatedAt := resource.UpdatedAt()
 
 	time.Sleep(10 * time.Millisecond)
@@ -154,24 +101,19 @@ func TestResource_UpdateStopFactor(t *testing.T) {
 }
 
 func TestResource_Update(t *testing.T) {
-	resource := NewResource("SP01", "RES001", nil, "MACHINE", 5, nil)
+	resource := NewResource("PLANT-01", "RES001", "MACHINE", 5, nil)
 	originalUpdatedAt := resource.UpdatedAt()
 
 	time.Sleep(10 * time.Millisecond)
 	newCode := "RES999"
-	newShiftID := "SHIFT999"
 	newType := "TOOL"
 	newStopFactor := int16(15)
 	newTags := []string{"new-tag"}
 
-	resource.Update(newCode, &newShiftID, newType, newStopFactor, newTags)
+	resource.Update(newCode, newType, newStopFactor, newTags)
 
 	if resource.Code() != newCode {
 		t.Errorf("Expected code '%s', got '%s'", newCode, resource.Code())
-	}
-
-	if resource.ShiftID() == nil || *resource.ShiftID() != newShiftID {
-		t.Error("ShiftID should be updated")
 	}
 
 	if resource.Type() != newType {
@@ -194,7 +136,6 @@ func TestResource_Update(t *testing.T) {
 func TestReconstructResource(t *testing.T) {
 	id := uuid.New()
 	code := "RES001"
-	shiftID := "SHIFT123"
 	resourceType := "MACHINE"
 	stopFactor := int16(5)
 	tags := []string{"tag1", "tag2"}
@@ -202,9 +143,8 @@ func TestReconstructResource(t *testing.T) {
 
 	resource := ReconstructResource(
 		id,
-		"SP01",
+		"PLANT-01",
 		code,
-		&shiftID,
 		resourceType,
 		stopFactor,
 		tags,
@@ -218,10 +158,6 @@ func TestReconstructResource(t *testing.T) {
 
 	if resource.Code() != code {
 		t.Error("Reconstructed resource should have correct code")
-	}
-
-	if resource.ShiftID() == nil || *resource.ShiftID() != shiftID {
-		t.Error("Reconstructed resource should have correct shiftID")
 	}
 
 	if resource.Type() != resourceType {
@@ -246,19 +182,17 @@ func TestReconstructResource(t *testing.T) {
 }
 
 func TestResource_AllGetters(t *testing.T) {
-	shiftID := "SHIFT123"
 	tags := []string{"tag1", "tag2"}
-	resource := NewResource("SP01", "RES001", &shiftID, "MACHINE", 5, tags)
+	resource := NewResource("PLANT-01", "RES001", "MACHINE", 5, tags)
 
-	// Test all getter methods
 	if resource.ID() == uuid.Nil {
 		t.Error("ID should not be nil")
 	}
+	if resource.LocationCode() != "PLANT-01" {
+		t.Error("LocationCode getter failed")
+	}
 	if resource.Code() != "RES001" {
 		t.Error("Code getter failed")
-	}
-	if resource.ShiftID() == nil || *resource.ShiftID() != shiftID {
-		t.Error("ShiftID getter failed")
 	}
 	if resource.Type() != "MACHINE" {
 		t.Error("Type getter failed")
@@ -278,7 +212,7 @@ func TestResource_AllGetters(t *testing.T) {
 }
 
 func TestResource_UpdateTags(t *testing.T) {
-	resource := NewResource("SP01", "RES001", nil, "MACHINE", 5, []string{"tag1"})
+	resource := NewResource("PLANT-01", "RES001", "MACHINE", 5, []string{"tag1"})
 	originalUpdatedAt := resource.UpdatedAt()
 
 	time.Sleep(10 * time.Millisecond)

--- a/internal/modules/production/infrastructure/adapter/input/http/resource_handler.go
+++ b/internal/modules/production/infrastructure/adapter/input/http/resource_handler.go
@@ -24,12 +24,11 @@ func NewResourceHandler(service input.ResourceService) *ResourceHandler {
 
 // Create handles the creation of a new resource
 func (h *ResourceHandler) Create(c *fiber.Ctx) error {
-	// Get plant code from URL parameter
-	plantCode := c.Params("plant_code")
-	if plantCode == "" {
+	locationCode := c.Params("location_code")
+	if locationCode == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
 			"invalid_request",
-			"Plant code is required in URL",
+			"Location code is required in URL",
 		))
 	}
 
@@ -42,13 +41,12 @@ func (h *ResourceHandler) Create(c *fiber.Ctx) error {
 		))
 	}
 
-	resource, err := h.service.Create(c.Context(), plantCode, req.Code, req.ShiftID, req.Type, req.StopFactor, req.Tags)
+	resource, err := h.service.Create(c.Context(), locationCode, req.Code, req.Type, req.StopFactor, req.Tags)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
-	response := dto.ToResourceResponse(resource)
-	return c.Status(fiber.StatusCreated).JSON(response)
+	return c.Status(fiber.StatusCreated).JSON(dto.ToResourceResponse(resource))
 }
 
 // GetByID handles retrieving a resource by ID
@@ -67,22 +65,20 @@ func (h *ResourceHandler) GetByID(c *fiber.Ctx) error {
 		return h.handleError(c, err)
 	}
 
-	response := dto.ToResourceResponse(resource)
-	return c.Status(fiber.StatusOK).JSON(response)
+	return c.Status(fiber.StatusOK).JSON(dto.ToResourceResponse(resource))
 }
 
 // GetByCode handles retrieving a resource by code
 func (h *ResourceHandler) GetByCode(c *fiber.Ctx) error {
-	// Get plant code from URL parameter
-	plantCode := c.Params("plant_code")
-	if plantCode == "" {
+	locationCode := c.Params("location_code")
+	if locationCode == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
 			"invalid_request",
-			"Plant code is required in URL",
+			"Location code is required in URL",
 		))
 	}
 
-	code := c.Params("code")
+	code := c.Params("res_code")
 	if code == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
 			"invalid_code",
@@ -90,13 +86,12 @@ func (h *ResourceHandler) GetByCode(c *fiber.Ctx) error {
 		))
 	}
 
-	resource, err := h.service.GetByCode(c.Context(), plantCode, code)
+	resource, err := h.service.GetByCode(c.Context(), locationCode, code)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
-	response := dto.ToResourceResponse(resource)
-	return c.Status(fiber.StatusOK).JSON(response)
+	return c.Status(fiber.StatusOK).JSON(dto.ToResourceResponse(resource))
 }
 
 // GetAll handles retrieving all resources with pagination
@@ -109,8 +104,7 @@ func (h *ResourceHandler) GetAll(c *fiber.Ctx) error {
 		return h.handleError(c, err)
 	}
 
-	response := dto.ToResourceListResponse(resources, limit, offset)
-	return c.Status(fiber.StatusOK).JSON(response)
+	return c.Status(fiber.StatusOK).JSON(dto.ToResourceListResponse(resources, limit, offset))
 }
 
 // GetByType handles retrieving resources by type
@@ -128,21 +122,6 @@ func (h *ResourceHandler) GetByType(c *fiber.Ctx) error {
 	})
 }
 
-// GetByShiftID handles retrieving resources by shift ID
-func (h *ResourceHandler) GetByShiftID(c *fiber.Ctx) error {
-	shiftID := c.Params("shiftId")
-	if shiftID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
-			"invalid_shift_id",
-			"Shift ID is required",
-		))
-	}
-
-	return h.getResourcesWithPagination(c, func(limit, offset int) ([]*entity.Resource, error) {
-		return h.service.GetByShiftID(c.Context(), shiftID, limit, offset)
-	})
-}
-
 // getResourcesWithPagination is a helper function to handle pagination logic
 func (h *ResourceHandler) getResourcesWithPagination(
 	c *fiber.Ctx,
@@ -156,18 +135,16 @@ func (h *ResourceHandler) getResourcesWithPagination(
 		return h.handleError(c, err)
 	}
 
-	response := dto.ToResourceListResponse(resources, limit, offset)
-	return c.Status(fiber.StatusOK).JSON(response)
+	return c.Status(fiber.StatusOK).JSON(dto.ToResourceListResponse(resources, limit, offset))
 }
 
 // Update handles updating an existing resource
 func (h *ResourceHandler) Update(c *fiber.Ctx) error {
-	// Get plant code from URL parameter
-	plantCode := c.Params("plant_code")
-	if plantCode == "" {
+	locationCode := c.Params("location_code")
+	if locationCode == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(dto.NewErrorResponse(
 			"invalid_request",
-			"Plant code is required in URL",
+			"Location code is required in URL",
 		))
 	}
 
@@ -188,13 +165,12 @@ func (h *ResourceHandler) Update(c *fiber.Ctx) error {
 		))
 	}
 
-	resource, err := h.service.Update(c.Context(), id, plantCode, req.Code, req.ShiftID, req.Type, req.StopFactor, req.Tags)
+	resource, err := h.service.Update(c.Context(), id, locationCode, req.Code, req.Type, req.StopFactor, req.Tags)
 	if err != nil {
 		return h.handleError(c, err)
 	}
 
-	response := dto.ToResourceResponse(resource)
-	return c.Status(fiber.StatusOK).JSON(response)
+	return c.Status(fiber.StatusOK).JSON(dto.ToResourceResponse(resource))
 }
 
 // Delete handles deleting a resource

--- a/internal/modules/production/infrastructure/adapter/input/http/routes.go
+++ b/internal/modules/production/infrastructure/adapter/input/http/routes.go
@@ -20,15 +20,13 @@ func NewProductionRoutes(resourceService input.ResourceService) *ProductionRoute
 
 // SetupRoutes registers all production routes with the Fiber app
 func (r *ProductionRoutes) SetupRoutes(app *fiber.App) {
-	resources := app.Group("/v1/api/production/plants/:plant_code")
+	resources := app.Group("/v1/api/production/locations/:location_code")
 
-	// Create a new resource in the specified plant
 	resources.Post("/resources/", r.resourceHandler.Create)
 	resources.Get("/resources/", r.resourceHandler.GetAll)
 	resources.Get("/resources/:id", r.resourceHandler.GetByID)
 	resources.Get("/resources/code/:res_code", r.resourceHandler.GetByCode)
 	resources.Get("/resources/type/:type", r.resourceHandler.GetByType)
-	resources.Get("/resources/shift/:shiftId", r.resourceHandler.GetByShiftID)
 	resources.Put("/resources/:id", r.resourceHandler.Update)
 	resources.Delete("/resources/:id", r.resourceHandler.Delete)
 }

--- a/internal/modules/production/infrastructure/adapter/output/persistence/memory_resource_repository.go
+++ b/internal/modules/production/infrastructure/adapter/output/persistence/memory_resource_repository.go
@@ -184,28 +184,3 @@ func (r *MemoryResourceRepository) FindByType(ctx context.Context, resourceType 
 	return filtered[offset:end], nil
 }
 
-// FindByShiftID retrieves all resources assigned to a specific shift
-func (r *MemoryResourceRepository) FindByShiftID(ctx context.Context, shiftID string, limit, offset int) ([]*entity.Resource, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	// Filter resources by shift ID
-	filtered := make([]*entity.Resource, 0)
-	for _, resource := range r.resources {
-		if resource.ShiftID() != nil && *resource.ShiftID() == shiftID {
-			filtered = append(filtered, resource)
-		}
-	}
-
-	// Apply pagination
-	if offset >= len(filtered) {
-		return []*entity.Resource{}, nil
-	}
-
-	end := offset + limit
-	if limit == 0 || end > len(filtered) {
-		end = len(filtered)
-	}
-
-	return filtered[offset:end], nil
-}

--- a/internal/modules/production/infrastructure/adapter/output/persistence/memory_resource_repository.go
+++ b/internal/modules/production/infrastructure/adapter/output/persistence/memory_resource_repository.go
@@ -183,4 +183,3 @@ func (r *MemoryResourceRepository) FindByType(ctx context.Context, resourceType 
 
 	return filtered[offset:end], nil
 }
-

--- a/internal/modules/production/infrastructure/adapter/output/persistence/memory_resource_repository_test.go
+++ b/internal/modules/production/infrastructure/adapter/output/persistence/memory_resource_repository_test.go
@@ -22,7 +22,7 @@ func TestMemoryResourceRepository_Save(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("save new resource", func(t *testing.T) {
-		resource := entity.NewResource("SP01", "RES001", nil, "machine", 5, nil)
+		resource := entity.NewResource("PLANT-01", "RES001", "machine", 5, nil)
 
 		err := repo.Save(ctx, resource)
 		if err != nil {
@@ -42,37 +42,16 @@ func TestMemoryResourceRepository_Save(t *testing.T) {
 		}
 	})
 
-	t.Run("save resource with shiftID", func(t *testing.T) {
-		shiftID := "shift123"
-		resource := entity.NewResource("SP01", "RES002", &shiftID, "machine", 5, nil)
-
-		err := repo.Save(ctx, resource)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-
-		found, err := repo.FindByID(ctx, resource.ID())
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if found.ShiftID() == nil {
-			t.Fatal("Expected shiftID to be set")
-		}
-		if *found.ShiftID() != shiftID {
-			t.Errorf("Expected shiftID %s, got %s", shiftID, *found.ShiftID())
-		}
-	})
-
 	t.Run("save duplicate code", func(t *testing.T) {
 		code := "RES003"
-		resource1 := entity.NewResource("SP01", code, nil, "machine", 5, nil)
+		resource1 := entity.NewResource("PLANT-01", code, "machine", 5, nil)
 
 		err := repo.Save(ctx, resource1)
 		if err != nil {
 			t.Fatalf("Expected no error on first save, got %v", err)
 		}
 
-		resource2 := entity.NewResource("SP01", code, nil, "tool", 3, nil)
+		resource2 := entity.NewResource("PLANT-01", code, "tool", 3, nil)
 
 		err = repo.Save(ctx, resource2)
 		if err == nil {
@@ -86,7 +65,7 @@ func TestMemoryResourceRepository_Update(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("update existing resource", func(t *testing.T) {
-		resource := entity.NewResource("SP01", "RES100", nil, "machine", 5, nil)
+		resource := entity.NewResource("PLANT-01", "RES100", "machine", 5, nil)
 
 		err := repo.Save(ctx, resource)
 		if err != nil {
@@ -113,7 +92,7 @@ func TestMemoryResourceRepository_Update(t *testing.T) {
 	})
 
 	t.Run("update non-existent resource", func(t *testing.T) {
-		resource := entity.NewResource("SP01", "RES101", nil, "machine", 5, nil)
+		resource := entity.NewResource("PLANT-01", "RES101", "machine", 5, nil)
 
 		// Try to update without saving first
 		err := repo.Update(ctx, resource)
@@ -128,7 +107,7 @@ func TestMemoryResourceRepository_Delete(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("delete existing resource", func(t *testing.T) {
-		resource := entity.NewResource("SP01", "RES200", nil, "machine", 5, nil)
+		resource := entity.NewResource("PLANT-01", "RES200", "machine", 5, nil)
 
 		err := repo.Save(ctx, resource)
 		if err != nil {
@@ -161,7 +140,7 @@ func TestMemoryResourceRepository_FindByID(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("find existing resource", func(t *testing.T) {
-		resource := entity.NewResource("SP01", "RES300", nil, "machine", 5, nil)
+		resource := entity.NewResource("PLANT-01", "RES300", "machine", 5, nil)
 
 		err := repo.Save(ctx, resource)
 		if err != nil {
@@ -195,7 +174,7 @@ func TestMemoryResourceRepository_FindByCode(t *testing.T) {
 
 	t.Run("find existing resource by code", func(t *testing.T) {
 		code := "RES400"
-		resource := entity.NewResource("SP01", code, nil, "machine", 5, nil)
+		resource := entity.NewResource("PLANT-01", code, "machine", 5, nil)
 
 		err := repo.Save(ctx, resource)
 		if err != nil {
@@ -227,7 +206,7 @@ func TestMemoryResourceRepository_ExistsByCode(t *testing.T) {
 	ctx := context.Background()
 
 	code := "RES500"
-	resource := entity.NewResource("SP01", code, nil, "machine", 5, nil)
+	resource := entity.NewResource("PLANT-01", code, "machine", 5, nil)
 
 	err := repo.Save(ctx, resource)
 	if err != nil {
@@ -262,7 +241,7 @@ func TestMemoryResourceRepository_FindAll(t *testing.T) {
 	// Create multiple resources
 	for i := 0; i < 5; i++ {
 		code := "RES600" + string(rune('A'+i))
-		resource := entity.NewResource("SP01", code, nil, "machine", int16(i), nil) // nolint:gosec
+		resource := entity.NewResource("PLANT-01", code, "machine", int16(i), nil) // nolint:gosec
 		err := repo.Save(ctx, resource)
 		if err != nil {
 			t.Fatalf("Failed to save resource: %v", err)
@@ -308,7 +287,7 @@ func TestMemoryResourceRepository_FindByType(t *testing.T) {
 	types := []string{"machine", "machine", "tool", "tool", "equipment"}
 	for i, resType := range types {
 		code := "RES700" + string(rune('A'+i))
-		resource := entity.NewResource("SP01", code, nil, resType, int16(i), nil) // nolint:gosec
+		resource := entity.NewResource("PLANT-01", code, resType, int16(i), nil) // nolint:gosec
 		err := repo.Save(ctx, resource)
 		if err != nil {
 			t.Fatalf("Failed to save resource: %v", err)
@@ -351,68 +330,6 @@ func TestMemoryResourceRepository_FindByType(t *testing.T) {
 	})
 }
 
-func TestMemoryResourceRepository_FindByShiftID(t *testing.T) {
-	repo := NewMemoryResourceRepository()
-	ctx := context.Background()
-
-	// Create resources with different shift IDs
-	shift1 := "shift001"
-	shift2 := "shift002"
-
-	resource1 := entity.NewResource("SP01", "RES800", &shift1, "machine", 1, nil)
-	resource2 := entity.NewResource("SP01", "RES801", &shift1, "tool", 2, nil)
-	resource3 := entity.NewResource("SP01", "RES802", &shift2, "machine", 3, nil)
-	resource4 := entity.NewResource("SP01", "RES803", nil, "tool", 4, nil)
-
-	if err := repo.Save(ctx, resource1); err != nil {
-		t.Fatalf("Failed to save resource1: %v", err)
-	}
-	if err := repo.Save(ctx, resource2); err != nil {
-		t.Fatalf("Failed to save resource2: %v", err)
-	}
-	if err := repo.Save(ctx, resource3); err != nil {
-		t.Fatalf("Failed to save resource3: %v", err)
-	}
-	if err := repo.Save(ctx, resource4); err != nil {
-		t.Fatalf("Failed to save resource4: %v", err)
-	}
-
-	t.Run("find by existing shift ID", func(t *testing.T) {
-		resources, err := repo.FindByShiftID(ctx, shift1, 10, 0)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if len(resources) != 2 {
-			t.Errorf("Expected 2 resources, got %d", len(resources))
-		}
-		for _, r := range resources {
-			if r.ShiftID() == nil || *r.ShiftID() != shift1 {
-				t.Errorf("Expected shiftID %s, got %v", shift1, r.ShiftID())
-			}
-		}
-	})
-
-	t.Run("find by non-existent shift ID", func(t *testing.T) {
-		resources, err := repo.FindByShiftID(ctx, "nonexistent", 10, 0)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if len(resources) != 0 {
-			t.Errorf("Expected 0 resources, got %d", len(resources))
-		}
-	})
-
-	t.Run("find by shift ID with pagination", func(t *testing.T) {
-		resources, err := repo.FindByShiftID(ctx, shift1, 1, 0)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if len(resources) != 1 {
-			t.Errorf("Expected 1 resource, got %d", len(resources))
-		}
-	})
-}
-
 func TestMemoryResourceRepository_ThreadSafety(t *testing.T) {
 	repo := NewMemoryResourceRepository()
 	ctx := context.Background()
@@ -426,7 +343,7 @@ func TestMemoryResourceRepository_ThreadSafety(t *testing.T) {
 			go func(idx int) {
 				defer wg.Done()
 				code := "CONCURRENT" + string(rune('A'+idx))
-				resource := entity.NewResource("SP01", code, nil, "machine", int16(idx), nil) // nolint:gosec
+				resource := entity.NewResource("PLANT-01", code, "machine", int16(idx), nil) // nolint:gosec
 				if err := repo.Save(ctx, resource); err != nil {
 					errors <- err
 				}
@@ -462,7 +379,7 @@ func TestMemoryResourceRepository_ThreadSafety(t *testing.T) {
 
 	t.Run("concurrent reads", func(t *testing.T) {
 		// Save a resource first
-		resource := entity.NewResource("SP01", "READTEST", nil, "machine", 5, nil)
+		resource := entity.NewResource("PLANT-01", "READTEST", "machine", 5, nil)
 		if err := repo.Save(ctx, resource); err != nil {
 			t.Fatalf("Failed to save test resource: %v", err)
 		}

--- a/internal/modules/production/infrastructure/dto/resource_dto.go
+++ b/internal/modules/production/infrastructure/dto/resource_dto.go
@@ -8,7 +8,6 @@ import (
 
 // CreateResourceRequest represents the request body for creating a resource
 type CreateResourceRequest struct {
-	ShiftID    *string  `json:"shift_id,omitempty"`
 	Code       string   `json:"code" validate:"required,min=2,max=50"`
 	Type       string   `json:"type" validate:"required,min=2,max=50"`
 	Tags       []string `json:"tags,omitempty"`
@@ -17,7 +16,6 @@ type CreateResourceRequest struct {
 
 // UpdateResourceRequest represents the request body for updating a resource
 type UpdateResourceRequest struct {
-	ShiftID    *string  `json:"shift_id,omitempty"`
 	Code       string   `json:"code" validate:"required,min=2,max=50"`
 	Type       string   `json:"type" validate:"required,min=2,max=50"`
 	Tags       []string `json:"tags,omitempty"`
@@ -26,14 +24,14 @@ type UpdateResourceRequest struct {
 
 // ResourceResponse represents the response body for resource data
 type ResourceResponse struct {
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	ShiftID    *string   `json:"shift_id,omitempty"`
-	ID         string    `json:"id"`
-	Code       string    `json:"code"`
-	Type       string    `json:"type"`
-	Tags       []string  `json:"tags,omitempty"`
-	StopFactor int16     `json:"stop_factor"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	ID           string    `json:"id"`
+	LocationCode string    `json:"location_code"`
+	Code         string    `json:"code"`
+	Type         string    `json:"type"`
+	Tags         []string  `json:"tags,omitempty"`
+	StopFactor   int16     `json:"stop_factor"`
 }
 
 // ResourceListResponse represents the response body for a list of resources
@@ -59,14 +57,14 @@ type SuccessResponse struct {
 // ToResourceResponse converts a Resource entity to ResourceResponse DTO
 func ToResourceResponse(resource *entity.Resource) ResourceResponse {
 	return ResourceResponse{
-		ID:         resource.ID().String(),
-		Code:       resource.Code(),
-		ShiftID:    resource.ShiftID(),
-		Type:       resource.Type(),
-		StopFactor: resource.StopFactor(),
-		Tags:       resource.Tags(),
-		CreatedAt:  resource.CreatedAt(),
-		UpdatedAt:  resource.UpdatedAt(),
+		ID:           resource.ID().String(),
+		LocationCode: resource.LocationCode(),
+		Code:         resource.Code(),
+		Type:         resource.Type(),
+		StopFactor:   resource.StopFactor(),
+		Tags:         resource.Tags(),
+		CreatedAt:    resource.CreatedAt(),
+		UpdatedAt:    resource.UpdatedAt(),
 	}
 }
 


### PR DESCRIPTION
## Summary

- **ShiftPattern domain** added to Organization module — rotating sequence of `ShiftEntry` items anchored to a reference date; `EntryForDate(date)` resolves the active shift entry via `(days since refStart) % periodDays`, supporting overnight shifts via `TimesForDate`
- **Shift instance** (Production module) created from a ShiftPattern at event time; its ID is stored on every production `Event` as `shiftID`
- **Location** now carries `shiftPatternID uuid.UUID` for AREA, LINE, and SECTION nodes; PLANT locations have no shift pattern (zero UUID)
- When creating a sub-location without specifying a pattern, the use case resolves the **default seeded pattern** via `ShiftPatternRepository.GetDefault()`
- **Default 3-Shift Rotation** seeded at boot: Morning 06:00–14:00 → Afternoon 14:00–22:00 → Night 22:00–06:00

## What changed

### Organization module
- `ShiftPattern` + `ShiftEntry` entity with `EntryForDate` / `TimesForDate`
- `ShiftPatternRepository` output port with `GetDefault()`
- In-memory `MemoryShiftPatternRepository` + `SeedDefaultShiftPatterns` seeder
- `Location.shiftPatternID` field + getter; `NewRootLocation` always stores zero UUID
- `AddLocationUseCase` injects `ShiftPatternRepository`; resolves default when `ShiftPatternID` is nil in command

### Production module
- `Shift` entity — concrete occurrence of a pattern (patternID, name, startAt, endAt)
- `Event` entity — all 12 `EventType` constants, `Close` method, getters
- `NewEventChangeShift` constructor — closes prev event at boundary, opens new one carrying over status/prodCode/userID
- `EventService` input port + implementation — 11 operator event transitions (`OperatorSignIn`, `InsertStop`, `ChangeShift`, etc.)
- `CreateResourceUseCase` — saves resource + `RESOURCE_CREATED` event with rollback on failure

## Test plan

- [ ] `go test ./...` passes (except pre-existing `fiber_server_test.go` failure unrelated to this PR)
- [ ] `make lint` reports 0 issues
- [ ] POST `/v1/api/organization/locations` creates a root location (PLANT) with zero ShiftPatternID
- [ ] POST `/v1/api/organization/locations/add` creates AREA/LINE/SECTION with default ShiftPatternID assigned automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)